### PR TITLE
docs: clarify datadog/otellog edges + enable GA

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,6 +4,7 @@ const defaultTitle = 'LogLayer for Go'
 const defaultDescription =
   'A transport-agnostic structured logging library for Go with a fluent API for messages, metadata, and errors.'
 const baseUrl = 'https://go.loglayer.dev'
+const gaMeasurementId = 'G-4SB3FY76P0'
 
 export default defineConfig({
   lang: 'en-US',
@@ -14,6 +15,22 @@ export default defineConfig({
   sitemap: { hostname: baseUrl },
   async transformHead({ pageData }) {
     const head: HeadConfig[] = [
+      // Google Analytics (gtag.js)
+      [
+        'script',
+        {
+          async: '',
+          src: `https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`,
+        },
+      ],
+      [
+        'script',
+        {},
+        `window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${gaMeasurementId}');`,
+      ],
       ['link', { rel: 'icon', href: '/images/icons/favicon.ico' }],
       ['link', { rel: 'manifest', href: '/images/icons/site.webmanifest' }],
       // Vanity import path for `go get go.loglayer.dev`. Go's

--- a/docs/src/plugins/datadogtrace.md
+++ b/docs/src/plugins/datadogtrace.md
@@ -186,6 +186,34 @@ cd plugins/datadogtrace/livetest && go test -race ./...
 
 CI runs it automatically on every push.
 
+## Troubleshooting
+
+### `unexpected status code: "403 Forbidden"` on stderr
+
+If you start dd-trace-go without a local Datadog Agent reachable on `localhost:8126`, you may see this line on stderr:
+
+```
+unexpected status code: "403 Forbidden" (received body: 79 bytes)
+```
+
+This is **not** from LogLayer or the Datadog log transport. It's emitted by dd-trace-go's own background **telemetry writer**, which tries to ship runtime metrics to Datadog through the Agent and falls back to a direct HTTPS path that requires Agent-issued auth. The 79-byte body is Datadog's `{"errors":[{"status":"403","title":"Forbidden","detail":"API key is missing"}]}`, which can be confusing because the same string also appears for *any* unauthorized intake request.
+
+Two ways to silence it:
+
+```sh
+# Option 1: disable dd-trace-go's telemetry (recommended for local dev)
+export DD_INSTRUMENTATION_TELEMETRY_ENABLED=false
+go run ./cmd/your-app
+```
+
+```go
+// Option 2: run a local Datadog Agent so the telemetry path works.
+// docker run -d -p 8126:8126 -e DD_API_KEY=... -e DD_APM_ENABLED=true \
+//   gcr.io/datadoghq/agent:latest
+```
+
+Your log entries are unaffected either way: the LogLayer Datadog transport ships them directly to the Logs intake with your `DD-API-KEY`, independent of dd-trace-go's telemetry channel.
+
 ## What it Does NOT Do
 
 - **Doesn't start its own tracer.** You're responsible for `tracer.Start(...)` and `tracer.Stop()`.

--- a/docs/src/transports/datadog.md
+++ b/docs/src/transports/datadog.md
@@ -62,15 +62,31 @@ datadog.New(datadog.Config{
 })
 ```
 
+The transport rejects non-HTTPS URLs by default. To point at an `httptest.Server` or a local plain-HTTP proxy, also set `AllowInsecureURL: true`:
+
+```go
+srv := httptest.NewServer(http.HandlerFunc(...))
+defer srv.Close()
+
+tr := datadog.New(datadog.Config{
+    APIKey:           "fake-for-tests",
+    URL:              srv.URL,        // http:// from httptest
+    AllowInsecureURL: true,           // required for non-HTTPS URLs
+})
+```
+
+`AllowInsecureURL` is a test/debug ergonomic; leave it off for any URL that leaves your machine.
+
 ## Config
 
 ```go
 type Config struct {
     transport.BaseConfig
 
-    APIKey   string  // required
-    Site     Site    // default SiteUS1; ignored when URL is set
-    URL      string  // overrides the Site-derived intake URL (on-prem / mock)
+    APIKey           string  // required
+    Site             Site    // default SiteUS1; ignored when URL is set
+    URL              string  // overrides the Site-derived intake URL (on-prem / mock)
+    AllowInsecureURL bool    // permit non-HTTPS URLs (httptest, local proxies)
 
     Source   string  // ddsource (e.g. "go")
     Service  string  // service name

--- a/docs/src/transports/otellog.md
+++ b/docs/src/transports/otellog.md
@@ -51,11 +51,20 @@ For explicit wiring (recommended in services that own their SDK setup):
 import (
     sdklog "go.opentelemetry.io/otel/sdk/log"
     "go.opentelemetry.io/otel/sdk/log/otlploghttp"
+    "go.opentelemetry.io/otel/sdk/resource"
+    semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+res := resource.NewSchemaless(
+    semconv.ServiceName("checkout-api"),
+    semconv.ServiceVersion("1.2.3"),
+    semconv.DeploymentEnvironment("production"),
 )
 
 exporter, _ := otlploghttp.New(ctx)
 provider := sdklog.NewLoggerProvider(
     sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter)),
+    sdklog.WithResource(res),
 )
 defer provider.Shutdown(ctx)
 
@@ -66,6 +75,12 @@ tr := otellog.New(otellog.Config{
 })
 ```
 
+::: warning Resource schema URL conflicts
+Wiring a resource with `resource.Merge(resource.Default(), resource.NewWithAttributes(semconv.SchemaURL, ...))` can fail with `conflicting Schema URL`: `resource.Default()` carries the SDK's current schema URL, while `semconv.SchemaURL` from a pinned import is older. The merge refuses to combine the two.
+
+Fix by either dropping the schema URL on your additions (`resource.NewSchemaless(...)`, shown above) or upgrading the `semconv` import to match `resource.Default()`'s schema. `resource.NewSchemaless` is the simpler choice for most apps; the schema URL only matters when downstream consumers do strict semantic-conventions validation.
+:::
+
 ## Pre-Built Logger (Tests, Advanced Wiring)
 
 When you've already constructed a `log.Logger` (or want to inject a stub in tests), pass it directly. `Logger` takes precedence over `LoggerProvider`/`Name`/`Version`/`SchemaURL`:
@@ -73,6 +88,37 @@ When you've already constructed a `log.Logger` (or want to inject a stub in test
 ```go
 tr := otellog.New(otellog.Config{Logger: myLogger})
 ```
+
+### Tests with `logtest.Recorder`
+
+For unit tests, the OTel project's [`logtest.Recorder`](https://pkg.go.dev/go.opentelemetry.io/otel/log/logtest#Recorder) implements `log.LoggerProvider` directly, so you can pass it straight to `Config.LoggerProvider` without an SDK provider, processor, or exporter in between:
+
+```go
+import "go.opentelemetry.io/otel/log/logtest"
+
+func TestEmits(t *testing.T) {
+    rec := logtest.NewRecorder()
+    log := loglayer.New(loglayer.Config{
+        Transport: otellog.New(otellog.Config{
+            Name:           "test",
+            LoggerProvider: rec,
+        }),
+    })
+
+    log.Info("user signed in")
+
+    for _, records := range rec.Result() {
+        for _, r := range records {
+            if r.Body.AsString() == "user signed in" {
+                return
+            }
+        }
+    }
+    t.Fatal("expected log record not captured")
+}
+```
+
+`rec.Result()` returns a `Recording` keyed by instrumentation scope; each value is a `[]logtest.Record` you can assert against (Body, Severity, Attributes, Context).
 
 ## Config
 


### PR DESCRIPTION
## Summary

Four small doc-site changes, all surfaced while building a sample project that exercises every transport, handler, and plugin end-to-end:

- **`docs/src/transports/datadog.md`** — Document the existing `AllowInsecureURL` config field. Without it, pointing the transport at an `httptest.Server` errors out on the non-HTTPS guard. Adds the field to the Config struct table and a short example under "On-prem / custom URL".

- **`docs/src/plugins/datadogtrace.md`** — New "Troubleshooting" section explaining that `unexpected status code: "403 Forbidden" (received body: 79 bytes)` on stderr comes from dd-trace-go's *own* background telemetry writer when no local Agent is reachable, not from LogLayer. Same 79-byte body Datadog returns for unauthorized log intake, so it's easy to misread. Two remediations: `DD_INSTRUMENTATION_TELEMETRY_ENABLED=false` or run a local Agent; either way the log shipping is unaffected.

- **`docs/src/transports/otellog.md`** — Two adds:
  - Warning callout about the `resource.Merge(resource.Default(), resource.NewWithAttributes(semconv.SchemaURL, ...))` "conflicting Schema URL" error, with `resource.NewSchemaless(...)` as the recommended workaround.
  - "Tests with `logtest.Recorder`" subsection: `logtest.NewRecorder()` implements `log.LoggerProvider`, so you can pass it directly as `Config.LoggerProvider` in tests — no `SimpleProcessor` / exporter wrapping needed. Includes a complete test example.

- **`docs/.vitepress/config.ts`** — Enable Google Analytics (`G-4SB3FY76P0`), mirroring the integration on the TypeScript loglayer docs site. Two `<script>` tags injected via `transformHead`, ID extracted to a `gaMeasurementId` constant.

## Test plan

- [ ] `make docs` (local VitePress build succeeds)
- [ ] Verify the GA snippet renders in the built `<head>` of every page
- [ ] After deploy, check Realtime view in the GA property for traffic
- [ ] Spot-check the three updated content pages render the new sections cleanly (warning callout, code blocks, table column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)