### PR TITLE
docs: bump release status and add version badge to nav

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -97,6 +97,7 @@ gtag('config', '${gaMeasurementId}');`,
     search: { provider: 'local' },
     outline: { level: [2, 3] },
     nav: [
+      { text: '<img alt="Latest version" src="https://img.shields.io/github/v/tag/loglayer/loglayer-go?filter=v*&amp;sort=semver&amp;label=version&amp;style=flat-square" />', link: 'https://github.com/loglayer/loglayer-go/releases' },
       { text: '<img alt="Go Reference" src="https://pkg.go.dev/badge/go.loglayer.dev.svg" />', link: 'https://pkg.go.dev/go.loglayer.dev' },
       { text: "What's New", link: '/whats-new' },
       { text: 'Get Started', link: '/getting-started' },

--- a/docs/src/whats-new.md
+++ b/docs/src/whats-new.md
@@ -5,9 +5,11 @@ description: User-visible changes to LogLayer for Go.
 
 # What's New
 
-## v1.0.0 (unreleased)
+## v1.0.0 (2026-04-29)
 
 Initial release. Stable API; SemVer applies from this point forward.
+
+Subsequent v1.0.x releases (v1.0.1, v1.0.2) are build- and test-only fixes (`go.sum` tidies, livetest repairs, release-please config). No user-visible behavior changes; full notes in [CHANGELOG.md](https://github.com/loglayer/loglayer-go/blob/main/CHANGELOG.md).
 
 LogLayer for Go is a transport-agnostic structured logging facade. One fluent API on top of any logging library, JSON, terminal, HTTP, OpenTelemetry, or your own transport.
 


### PR DESCRIPTION
## Summary

Two small doc-site fixes:

- **`docs/src/whats-new.md`** — page still said `v1.0.0 (unreleased)` after v1.0.0/v1.0.1/v1.0.2 shipped on 2026-04-29. Marks v1.0.0 as released and adds a short pointer noting that v1.0.1 / v1.0.2 are build- and test-only fixes (no user-visible behavior change), with full per-version notes in `CHANGELOG.md`.

- **`docs/.vitepress/config.ts`** — adds a version badge to the nav header, mirroring the npm version badge on the TypeScript loglayer docs. Uses `filter=v*&sort=semver` against the GitHub tags API so the main-module tags are picked up cleanly without `transports/.../vX.Y.Z` or `plugins/.../vX.Y.Z` submodule tags polluting the value.

## Test plan

- [ ] `make docs` — local VitePress build succeeds
- [ ] After deploy, version badge in the nav reads `version v1.0.x`
- [ ] Clicking the badge opens the GitHub releases page
- [ ] What's New no longer reads "unreleased"

🤖 Generated with [Claude Code](https://claude.com/claude-code)