### PR TITLE
docs(readme): add version badge to header

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 # LogLayer for Go
 
 <p align="center">
+  <a href="https://github.com/loglayer/loglayer-go/releases"><img src="https://img.shields.io/github/v/tag/loglayer/loglayer-go?filter=v*&sort=semver&label=version&style=flat-square" alt="Latest version"></a>
   <a href="https://pkg.go.dev/go.loglayer.dev"><img src="https://pkg.go.dev/badge/go.loglayer.dev.svg" alt="Go Reference"></a>
   <a href="https://github.com/loglayer/loglayer-go/actions/workflows/ci.yml"><img src="https://github.com/loglayer/loglayer-go/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>


### PR DESCRIPTION
## Summary

Adds a version badge to the README badges row, mirroring the same badge on the docs site nav (PR #6, merged) and the LogLayer org profile README. Reads from the GitHub tags API with `filter=v*&sort=semver` so the main-module's `v1.0.x` tags drive it, without `transports/.../vX.Y.Z` or `plugins/.../vX.Y.Z` submodule tags polluting the value. Linked to the GitHub releases page.

Final badge order: `version` → `Go Reference` → `CI` → `MIT License`.

## Test plan

- [x] Confirm badge URL renders (HTTP 200, SVG)
- [ ] After merge, GitHub README shows `version v1.0.x` as the leftmost badge
- [ ] Click opens https://github.com/loglayer/loglayer-go/releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)