### PR TITLE
chore(release-please): expose refactor and force v2.0.0

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,6 +5,20 @@
   "prerelease": false,
   "include-component-in-tag": true,
   "tag-separator": "/",
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "refactor", "section": "Code Refactoring" },
+    { "type": "deps", "section": "Dependencies" },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "build", "section": "Build System", "hidden": true },
+    { "type": "ci", "section": "Continuous Integration", "hidden": true }
+  ],
   "packages": {
     ".": {
       "release-type": "go",


### PR DESCRIPTION
## Summary

The fmtlog import-path migration in #7 was a `refactor!:` commit with a `BREAKING CHANGE:` footer. Per Conventional Commits 1.0 it should have triggered a major-version bump, but release-please's workflow ran on the merge of #7 and decided "No user facing commits found - skipping" — no release PR was opened.

Root cause: in release-please-action's current behaviour, the "is this commit user-facing?" filter runs *before* the breaking-change check. The default config hides `refactor` (along with `docs`/`chore`/`style`/`test`/`build`/`ci`) from the changelog, so a `refactor!:` commit is classified as hidden first and the `!` never gets to vote.

## Changes

**1. Make `refactor` visible by default** (and explicitly enumerate the other sections so the config is self-documenting): adds an explicit `changelog-sections` array at the root of `.release-please-config.json`. After this, `refactor!:` correctly bumps the major version and lands under "Code Refactoring" in the changelog. Future breaking refactors will Just Work.

**2. Force a v2.0.0 release** for the main module via the `Release-As: 2.0.0` footer in this commit, so the fmtlog change in #7 ships right away rather than waiting for some other `feat` or `fix` to land. Next release-please run after merge will open the v2.0.0 release PR.

## Test plan

- [x] JSON validates
- [x] Pre-push race tests pass
- [ ] After merge, the next release-please workflow run opens a `chore: release main` PR proposing v2.0.0
- [ ] That PR's CHANGELOG entry includes the fmtlog refactor under "Code Refactoring" with a "BREAKING CHANGES" call-out
- [ ] Merging the release PR creates the `v2.0.0` git tag and a GitHub Release

## Notes

There is also a separate latent issue: the manifest + CHANGELOG show v1.0.2 as released but no `v1.0.2` git tag exists (the bug fix in `fix(release-please): correct field name (tag-separator, not separator)` was the cause; that fix shipped *in* the broken release). Not addressed by this PR — release-please should re-tag at v2.0.0 cleanly. If we ever need to backfill v1.0.2, that's a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)