### PR TITLE
refactor: split eight bundled sub-packages into independent modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,9 @@ profile.cov
 # vendor/
 
 # Go workspace file
-go.work
+# go.work itself IS committed (this monorepo has multiple modules and
+# every contributor needs the same workspace layout). Only the env-
+# specific go.work.sum is ignored.
 go.work.sum
 
 # env file

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -95,6 +95,62 @@
       "component": "plugins/oteltrace",
       "include-component-in-tag": true,
       "changelog-path": "CHANGELOG.md"
+    },
+    "transports/blank": {
+      "release-type": "go",
+      "package-name": "go.loglayer.dev/transports/blank",
+      "component": "transports/blank",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "transports/slog": {
+      "release-type": "go",
+      "package-name": "go.loglayer.dev/transports/slog",
+      "component": "transports/slog",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "plugins/redact": {
+      "release-type": "go",
+      "package-name": "go.loglayer.dev/plugins/redact",
+      "component": "plugins/redact",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "plugins/sampling": {
+      "release-type": "go",
+      "package-name": "go.loglayer.dev/plugins/sampling",
+      "component": "plugins/sampling",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "plugins/fmtlog": {
+      "release-type": "go",
+      "package-name": "go.loglayer.dev/plugins/fmtlog",
+      "component": "plugins/fmtlog",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "plugins/datadogtrace": {
+      "release-type": "go",
+      "package-name": "go.loglayer.dev/plugins/datadogtrace",
+      "component": "plugins/datadogtrace",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "integrations/loghttp": {
+      "release-type": "go",
+      "package-name": "go.loglayer.dev/integrations/loghttp",
+      "component": "integrations/loghttp",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "integrations/sloghandler": {
+      "release-type": "go",
+      "package-name": "go.loglayer.dev/integrations/sloghandler",
+      "component": "integrations/sloghandler",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
     }
   },
   "plugins": [

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  ".": "2.0.0",
+  ".": "1.0.2",
   "transports/charmlog": "1.0.1",
   "transports/datadog": "1.0.0",
   "transports/http": "1.0.0",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -9,5 +9,13 @@
   "transports/pretty": "1.0.0",
   "transports/zap": "1.0.1",
   "transports/zerolog": "1.0.0",
-  "plugins/oteltrace": "1.0.1"
+  "plugins/oteltrace": "1.0.1",
+  "transports/blank": "1.0.0",
+  "transports/slog": "1.0.0",
+  "plugins/redact": "1.0.0",
+  "plugins/sampling": "1.0.0",
+  "plugins/fmtlog": "1.0.0",
+  "plugins/datadogtrace": "1.0.0",
+  "integrations/loghttp": "1.0.0",
+  "integrations/sloghandler": "1.0.0"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,12 +55,19 @@ loglayer-go/
 - **No `Logger` interface in core**: Go convention is "consumer defines the interface."
   Application code accepts the concrete `*loglayer.LogLayer`; `loglayer.NewMock()` returns
   the same type for test injection.
-- **Multi-module layout**: the main `go.loglayer.dev` module hosts the framework core (loglayer/builder/dispatch/plugin/level/etc.), the `transport/` package (BaseTransport, helpers, transporttest, benchtest), the in-stdlib renderer transports (blank/console/structured/testing), the slog wrapper (stdlib only), `integrations/loghttp`, plugins/{redact,datadogtrace,plugintest}, and utils/{maputil,sanitize,idgen}. Every other transport and plugin lives in its own Go module so consumers only pay for the SDKs they actually import:
+- **Multi-module layout**: the main `go.loglayer.dev` module hosts the framework core (loglayer/builder/dispatch/plugin/level/etc.), the `transport/` package (BaseTransport, helpers, transporttest, benchtest), the renderer transports that main's own tests/examples consume (`transports/console`, `transports/structured`, `transports/testing`), `plugins/plugintest`, and the `utils/{maputil,sanitize,idgen}` helpers. Every other transport, plugin, and integration ships as its own Go module so consumers only pay for the SDKs they import *and* a breaking change in any one of them stays local to that sub-module's major version:
+  - `transports/blank` (stdlib only — example/prototype dispatcher)
   - `transports/pretty` (fatih/color)
   - `transports/http`, `transports/datadog` (network shippers; datadog wraps http)
+  - `transports/slog` (stdlib `log/slog` wrapper)
   - `transports/zerolog`, `transports/zap`, `transports/logrus`, `transports/phuslu`, `transports/charmlog` (vendor wrappers)
   - `transports/otellog`, `plugins/oteltrace` (OTel SDK; Go 1.25 floor)
+  - `plugins/redact`, `plugins/sampling`, `plugins/fmtlog`, `plugins/datadogtrace` (stdlib-only plugins, but each independently versionable)
   - `plugins/datadogtrace/livetest` (test-only, dd-trace-go v2)
+  - `integrations/loghttp` (HTTP middleware; stdlib only)
+  - `integrations/sloghandler` (stdlib `log/slog` adapter)
+
+  **Why so many split modules** — once a sub-package starts to look like an independent shipping unit (its own users, its own breaking-change cadence), splitting early avoids being trapped later. A breaking change in, say, `plugins/redact` only forces `plugins/redact/v2`; the main `go.loglayer.dev` import path is unaffected. Pre-split, every breaking refactor cascaded into a `go.loglayer.dev/v2` semantic-import-versioning migration. The packages still bundled in main are only those whose split would create a require cycle with main's own tests/examples.
 
   Each sub-module has its own `go.mod` with a `replace go.loglayer.dev => ../..` (and any relevant sibling) directive for development. A `go.work` at the repo root lets `gopls` and `go test all` see every module from a single root; CI uses `scripts/foreach-module.sh` which runs each module in isolation and is unaffected.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning
 follows [SemVer](https://semver.org/spec/v2.0.0.html).
 
-`go.loglayer.dev` is the main module. Three sub-modules ship under their
-own tags: `go.loglayer.dev/transports/otellog`,
-`go.loglayer.dev/plugins/oteltrace`, and (test-only)
-`go.loglayer.dev/plugins/datadogtrace/livetest`. See `AGENTS.md` for the
-splitting policy and release flow.
+`go.loglayer.dev` is the main module. Most transports, plugins, and
+integrations ship as their own sub-modules under their own tags
+(e.g. `go.loglayer.dev/transports/datadog`,
+`go.loglayer.dev/plugins/redact`,
+`go.loglayer.dev/integrations/loghttp`). The full list lives in
+`.release-please-manifest.json`. See `AGENTS.md` for the splitting
+policy and release flow.
 
 Releases are managed by [Release Please](https://github.com/googleapis/release-please)
 from conventional commits. From v1.0.0 forward, this file is maintained

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,22 +15,6 @@ from conventional commits. From v1.0.0 forward, this file is maintained
 automatically; the `[Unreleased]` section below describes the initial
 release at a high level.
 
-## [2.0.0](https://github.com/loglayer/loglayer-go/compare/v1.0.2...v2.0.0) (2026-04-29)
-
-
-### ⚠ BREAKING CHANGES
-
-* **fmtlog:** the fmtlog plugin's import path changes from `go.loglayer.dev/fmtlog` to `go.loglayer.dev/plugins/fmtlog`. Update imports accordingly.
-
-### Code Refactoring
-
-* **fmtlog:** Move fmtlog from /fmtlog to /plugins/fmtlog ([#7](https://github.com/loglayer/loglayer-go/issues/7)) ([165cd4b](https://github.com/loglayer/loglayer-go/commit/165cd4b06cc8bbb290cf7d8d8930066a2c222f07))
-
-
-### Miscellaneous Chores
-
-* **release-please:** Expose refactor in changelog and force v2.0.0 ([#9](https://github.com/loglayer/loglayer-go/issues/9)) ([f3a980e](https://github.com/loglayer/loglayer-go/commit/f3a980e6eefa1e7b9f25a86d3f68de475de20534)), closes [#7](https://github.com/loglayer/loglayer-go/issues/7)
-
 ## [1.0.2](https://github.com/loglayer/loglayer-go/compare/v1.0.1...v1.0.2) (2026-04-29)
 
 

--- a/docs/src/integrations/loghttp.md
+++ b/docs/src/integrations/loghttp.md
@@ -5,7 +5,7 @@ description: One-line HTTP middleware that derives a per-request logger and stuf
 
 # HTTP Middleware (loghttp)
 
-<ModuleBadges path="integrations/loghttp" bundled />
+<ModuleBadges path="integrations/loghttp" />
 
 `integrations/loghttp` is HTTP middleware that does the per-request logger derivation for you. Drop it into your router once at startup, and every handler downstream gets a logger pre-populated with `requestId`, `method`, `path`. The middleware also emits a "request completed" log line at the end of every request with status code, bytes written, and duration.
 

--- a/docs/src/integrations/sloghandler.md
+++ b/docs/src/integrations/sloghandler.md
@@ -5,7 +5,7 @@ description: "slog.Handler that routes every slog.Info(...) call through your lo
 
 # slog Handler
 
-<ModuleBadges path="integrations/sloghandler" bundled />
+<ModuleBadges path="integrations/sloghandler" />
 
 `integrations/sloghandler` is a `log/slog.Handler` backed by a loglayer logger. Once installed, every `slog.Info(...)` call (yours or your dependencies') flows through loglayer's plugin pipeline, multi-transport fan-out, group routing, and level filtering.
 

--- a/docs/src/plugins/datadogtrace.md
+++ b/docs/src/plugins/datadogtrace.md
@@ -5,7 +5,7 @@ description: "Inject Datadog APM trace and span IDs into log entries for log/tra
 
 # Datadog APM Trace Injector Plugin
 
-<ModuleBadges path="plugins/datadogtrace" bundled />
+<ModuleBadges path="plugins/datadogtrace" />
 
 `plugins/datadogtrace` adds Datadog's [log/trace correlation](https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/) fields to every log entry that carries an active span via `WithContext`. Once your logs ship to Datadog, the UI will link each log line to the trace it originated in.
 

--- a/docs/src/plugins/fmtlog.md
+++ b/docs/src/plugins/fmtlog.md
@@ -5,7 +5,7 @@ description: "Opt-in fmt.Sprintf semantics for multi-arg log calls."
 
 # Format Strings
 
-<ModuleBadges path="plugins/fmtlog" bundled />
+<ModuleBadges path="plugins/fmtlog" />
 
 `fmtlog` is a one-line plugin that opts a logger into `fmt.Sprintf`-style format strings. After registration, every call where the first message is a string and there are extra arguments is rewritten via `fmt.Sprintf(messages[0], messages[1:]...)` before downstream `MessageHook`s run.
 
@@ -13,7 +13,7 @@ description: "Opt-in fmt.Sprintf semantics for multi-arg log calls."
 go get go.loglayer.dev/plugins/fmtlog
 ```
 
-The package is a sub-package of `go.loglayer.dev` (no extra dependencies; ships with the main module).
+`fmtlog` is its own Go module under `go.loglayer.dev/plugins/fmtlog`, with no third-party dependencies beyond the main `go.loglayer.dev` module it implements `Plugin` against.
 
 ## Basic Usage
 

--- a/docs/src/plugins/redact.md
+++ b/docs/src/plugins/redact.md
@@ -5,7 +5,7 @@ description: "Replace values for sensitive keys, value patterns, or struct field
 
 # Redact Plugin
 
-<ModuleBadges path="plugins/redact" bundled />
+<ModuleBadges path="plugins/redact" />
 
 `plugins/redact` replaces sensitive values in metadata and persistent fields before any transport sees them. Useful for keeping secrets, PII, and credentials out of log output without rewriting every call site.
 

--- a/docs/src/plugins/sampling.md
+++ b/docs/src/plugins/sampling.md
@@ -5,7 +5,7 @@ description: "Drop a fraction of log emissions to keep volume and cost under con
 
 # Sampling Plugin
 
-<ModuleBadges path="plugins/sampling" bundled />
+<ModuleBadges path="plugins/sampling" />
 
 `plugins/sampling` keeps log volume bounded by dropping a fraction of emissions before any transport sees them. Three strategies built on the [`SendGate`](/plugins/creating-plugins#sendgate) hook:
 

--- a/docs/src/transports/blank.md
+++ b/docs/src/transports/blank.md
@@ -5,7 +5,7 @@ description: A bring-your-own-function Transport for prototyping or one-off inte
 
 # Blank Transport
 
-<ModuleBadges path="transports/blank" bundled />
+<ModuleBadges path="transports/blank" />
 
 The `blank` transport delegates `SendToLogger` to a function you supply inline. Use it for:
 

--- a/docs/src/transports/slog.md
+++ b/docs/src/transports/slog.md
@@ -5,7 +5,7 @@ description: Wrap a *slog.Logger with LogLayer.
 
 # log/slog Transport
 
-<ModuleBadges path="transports/slog" bundled />
+<ModuleBadges path="transports/slog" />
 
 Wraps a stdlib `*log/slog.Logger`. Map metadata flattens to `slog.Attr`s; struct metadata lands under a configurable key. Per-call `context.Context` attached via `WithContext` is passed through to `slog.Logger.LogAttrs` so handlers downstream (OpenTelemetry, structured shippers) can extract trace context.
 

--- a/examples/http-server/go.mod
+++ b/examples/http-server/go.mod
@@ -11,3 +11,5 @@ require (
 	go.loglayer.dev v0.0.0-00010101000000-000000000000
 	go.loglayer.dev/integrations/loghttp v0.0.0-00010101000000-000000000000
 )
+
+require github.com/goccy/go-json v0.10.6 // indirect

--- a/examples/http-server/go.mod
+++ b/examples/http-server/go.mod
@@ -1,0 +1,13 @@
+module go.loglayer.dev/examples/http-server
+
+go 1.25.0
+
+replace (
+	go.loglayer.dev => ../..
+	go.loglayer.dev/integrations/loghttp => ../../integrations/loghttp
+)
+
+require (
+	go.loglayer.dev v0.0.0-00010101000000-000000000000
+	go.loglayer.dev/integrations/loghttp v0.0.0-00010101000000-000000000000
+)

--- a/examples/http-server/go.sum
+++ b/examples/http-server/go.sum
@@ -1,0 +1,4 @@
+github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
+github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/go.work
+++ b/go.work
@@ -1,0 +1,33 @@
+go 1.25.0
+
+use (
+	.
+
+	./transports/blank
+	./transports/charmlog
+	./transports/datadog
+	./transports/http
+	./transports/logrus
+	./transports/otellog
+	./transports/phuslu
+	./transports/pretty
+	./transports/slog
+	./transports/zap
+	./transports/zerolog
+
+	./plugins/datadogtrace
+	./plugins/datadogtrace/livetest
+	./plugins/fmtlog
+	./plugins/oteltrace
+	./plugins/redact
+	./plugins/sampling
+
+	./integrations/loghttp
+	./integrations/sloghandler
+
+	./examples/custom-plugin
+	./examples/datadog-shipping
+	./examples/http-server
+	./examples/multi-transport
+	./examples/otel-end-to-end
+)

--- a/integrations/loghttp/go.mod
+++ b/integrations/loghttp/go.mod
@@ -1,0 +1,7 @@
+module go.loglayer.dev/integrations/loghttp
+
+go 1.25.0
+
+replace go.loglayer.dev => ../..
+
+require go.loglayer.dev v0.0.0-00010101000000-000000000000

--- a/integrations/loghttp/go.mod
+++ b/integrations/loghttp/go.mod
@@ -5,3 +5,5 @@ go 1.25.0
 replace go.loglayer.dev => ../..
 
 require go.loglayer.dev v0.0.0-00010101000000-000000000000
+
+require github.com/goccy/go-json v0.10.6 // indirect

--- a/integrations/loghttp/go.sum
+++ b/integrations/loghttp/go.sum
@@ -1,0 +1,4 @@
+github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
+github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/integrations/sloghandler/go.mod
+++ b/integrations/sloghandler/go.mod
@@ -5,3 +5,5 @@ go 1.25.0
 replace go.loglayer.dev => ../..
 
 require go.loglayer.dev v0.0.0-00010101000000-000000000000
+
+require github.com/goccy/go-json v0.10.6 // indirect

--- a/integrations/sloghandler/go.mod
+++ b/integrations/sloghandler/go.mod
@@ -1,0 +1,7 @@
+module go.loglayer.dev/integrations/sloghandler
+
+go 1.25.0
+
+replace go.loglayer.dev => ../..
+
+require go.loglayer.dev v0.0.0-00010101000000-000000000000

--- a/integrations/sloghandler/go.sum
+++ b/integrations/sloghandler/go.sum
@@ -1,0 +1,4 @@
+github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
+github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/integrations/sloghandler/sloghandler_test.go
+++ b/integrations/sloghandler/sloghandler_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -12,7 +11,6 @@ import (
 
 	"go.loglayer.dev"
 	"go.loglayer.dev/integrations/sloghandler"
-	"go.loglayer.dev/plugins/redact"
 	lltest "go.loglayer.dev/transports/testing"
 )
 
@@ -349,8 +347,26 @@ func TestPluginPipeline_Runs(t *testing.T) {
 		Transport:        lltest.New(lltest.Config{Library: lib}),
 		DisableFatalExit: true,
 	})
-	log.AddPlugin(redact.New(redact.Config{
-		Patterns: []*regexp.Regexp{regexp.MustCompile(`secret-`)},
+
+	// Inline DataHook plugin: rewrites any string value starting with
+	// "secret-" to "[REDACTED]". This used to use the standalone redact
+	// plugin, but pulling that in created a cross-module test
+	// dependency we don't otherwise need. The test isn't really about
+	// redact; it's verifying that values arriving via the slog adapter
+	// participate in the plugin pipeline at all.
+	log.AddPlugin(loglayer.NewDataHook("test-redactor", func(p loglayer.BeforeDataOutParams) loglayer.Data {
+		if p.Data == nil {
+			return nil
+		}
+		out := make(loglayer.Data, len(p.Data))
+		for k, v := range p.Data {
+			if s, ok := v.(string); ok && strings.HasPrefix(s, "secret-") {
+				out[k] = "[REDACTED]"
+			} else {
+				out[k] = v
+			}
+		}
+		return out
 	}))
 
 	l := slog.New(sloghandler.New(log))
@@ -358,7 +374,7 @@ func TestPluginPipeline_Runs(t *testing.T) {
 
 	line := lib.PopLine()
 	if line.Data["token"] != "[REDACTED]" {
-		t.Errorf("redact plugin should rewrite values arriving from slog: got %v", line.Data["token"])
+		t.Errorf("plugin should rewrite values arriving from slog: got %v", line.Data["token"])
 	}
 }
 

--- a/plugins/datadogtrace/go.mod
+++ b/plugins/datadogtrace/go.mod
@@ -5,3 +5,5 @@ go 1.25.0
 replace go.loglayer.dev => ../..
 
 require go.loglayer.dev v0.0.0-00010101000000-000000000000
+
+require github.com/goccy/go-json v0.10.6 // indirect

--- a/plugins/datadogtrace/go.mod
+++ b/plugins/datadogtrace/go.mod
@@ -1,0 +1,7 @@
+module go.loglayer.dev/plugins/datadogtrace
+
+go 1.25.0
+
+replace go.loglayer.dev => ../..
+
+require go.loglayer.dev v0.0.0-00010101000000-000000000000

--- a/plugins/datadogtrace/go.sum
+++ b/plugins/datadogtrace/go.sum
@@ -1,0 +1,4 @@
+github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
+github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/plugins/datadogtrace/livetest/go.mod
+++ b/plugins/datadogtrace/livetest/go.mod
@@ -2,11 +2,15 @@ module go.loglayer.dev/plugins/datadogtrace/livetest
 
 go 1.25.0
 
-replace go.loglayer.dev => ../../..
+replace (
+	go.loglayer.dev => ../../..
+	go.loglayer.dev/plugins/datadogtrace => ..
+)
 
 require (
 	github.com/DataDog/dd-trace-go/v2 v2.7.3
 	go.loglayer.dev v0.0.0-00010101000000-000000000000
+	go.loglayer.dev/plugins/datadogtrace v0.0.0-00010101000000-000000000000
 )
 
 require (

--- a/plugins/fmtlog/go.mod
+++ b/plugins/fmtlog/go.mod
@@ -1,0 +1,7 @@
+module go.loglayer.dev/plugins/fmtlog
+
+go 1.25.0
+
+replace go.loglayer.dev => ../..
+
+require go.loglayer.dev v0.0.0-00010101000000-000000000000

--- a/plugins/fmtlog/go.mod
+++ b/plugins/fmtlog/go.mod
@@ -5,3 +5,5 @@ go 1.25.0
 replace go.loglayer.dev => ../..
 
 require go.loglayer.dev v0.0.0-00010101000000-000000000000
+
+require github.com/goccy/go-json v0.10.6 // indirect

--- a/plugins/fmtlog/go.sum
+++ b/plugins/fmtlog/go.sum
@@ -1,0 +1,4 @@
+github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
+github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/plugins/redact/go.mod
+++ b/plugins/redact/go.mod
@@ -5,3 +5,5 @@ go 1.25.0
 replace go.loglayer.dev => ../..
 
 require go.loglayer.dev v0.0.0-00010101000000-000000000000
+
+require github.com/goccy/go-json v0.10.6 // indirect

--- a/plugins/redact/go.mod
+++ b/plugins/redact/go.mod
@@ -1,0 +1,7 @@
+module go.loglayer.dev/plugins/redact
+
+go 1.25.0
+
+replace go.loglayer.dev => ../..
+
+require go.loglayer.dev v0.0.0-00010101000000-000000000000

--- a/plugins/redact/go.sum
+++ b/plugins/redact/go.sum
@@ -1,0 +1,4 @@
+github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
+github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/plugins/sampling/go.mod
+++ b/plugins/sampling/go.mod
@@ -5,3 +5,5 @@ go 1.25.0
 replace go.loglayer.dev => ../..
 
 require go.loglayer.dev v0.0.0-00010101000000-000000000000
+
+require github.com/goccy/go-json v0.10.6 // indirect

--- a/plugins/sampling/go.mod
+++ b/plugins/sampling/go.mod
@@ -1,0 +1,7 @@
+module go.loglayer.dev/plugins/sampling
+
+go 1.25.0
+
+replace go.loglayer.dev => ../..
+
+require go.loglayer.dev v0.0.0-00010101000000-000000000000

--- a/plugins/sampling/go.sum
+++ b/plugins/sampling/go.sum
@@ -1,0 +1,4 @@
+github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
+github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/scripts/foreach-module.sh
+++ b/scripts/foreach-module.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 # sub-modules. Don't reorder without a reason.
 ALL_MODULES=(
   .
+  transports/blank
   transports/charmlog
   transports/datadog
   transports/http
@@ -22,12 +23,20 @@ ALL_MODULES=(
   transports/otellog
   transports/phuslu
   transports/pretty
+  transports/slog
   transports/zap
   transports/zerolog
-  plugins/oteltrace
+  plugins/datadogtrace
   plugins/datadogtrace/livetest
+  plugins/fmtlog
+  plugins/oteltrace
+  plugins/redact
+  plugins/sampling
+  integrations/loghttp
+  integrations/sloghandler
   examples/custom-plugin
   examples/datadog-shipping
+  examples/http-server
   examples/multi-transport
   examples/otel-end-to-end
 )
@@ -37,6 +46,7 @@ ALL_MODULES=(
 # of example code shouldn't gate the build.
 SHIPPED_MODULES=(
   .
+  transports/blank
   transports/charmlog
   transports/datadog
   transports/http
@@ -44,9 +54,16 @@ SHIPPED_MODULES=(
   transports/otellog
   transports/phuslu
   transports/pretty
+  transports/slog
   transports/zap
   transports/zerolog
+  plugins/datadogtrace
+  plugins/fmtlog
   plugins/oteltrace
+  plugins/redact
+  plugins/sampling
+  integrations/loghttp
+  integrations/sloghandler
 )
 
 op="${1:-}"
@@ -113,6 +130,7 @@ case "$op" in
     # "[no test files]" output. Every other module has tests.
     for mod in \
       . \
+      transports/blank \
       transports/charmlog \
       transports/datadog \
       transports/http \
@@ -120,10 +138,17 @@ case "$op" in
       transports/otellog \
       transports/phuslu \
       transports/pretty \
+      transports/slog \
       transports/zap \
       transports/zerolog \
+      plugins/datadogtrace \
+      plugins/datadogtrace/livetest \
+      plugins/fmtlog \
       plugins/oteltrace \
-      plugins/datadogtrace/livetest; do
+      plugins/redact \
+      plugins/sampling \
+      integrations/loghttp \
+      integrations/sloghandler; do
       echo "==> $mod (test)"
       (cd "$mod" && go test -race -count=1 ./...)
     done

--- a/transport/concurrency_test.go
+++ b/transport/concurrency_test.go
@@ -6,14 +6,21 @@ import (
 
 	"go.loglayer.dev"
 	"go.loglayer.dev/transport"
-	"go.loglayer.dev/transports/blank"
+	lltest "go.loglayer.dev/transports/testing"
 )
 
 // TestSetEnabledNoRace exercises the contract that BaseTransport.SetEnabled
 // is safe to call concurrently with emission. The -race detector runs this
 // test; if SetEnabled isn't atomic, this test must fail.
+//
+// Uses the in-process lltest transport (which stays bundled in the main
+// module) rather than transports/blank, because blank now lives in its own
+// module and importing it here would create a require cycle with main.
 func TestSetEnabledNoRace(t *testing.T) {
-	tr := blank.New(blank.Config{BaseConfig: transport.BaseConfig{ID: "b"}})
+	tr := lltest.New(lltest.Config{
+		BaseConfig: transport.BaseConfig{ID: "b"},
+		Library:    &lltest.TestLoggingLibrary{},
+	})
 	log := loglayer.New(loglayer.Config{Transport: tr, DisableFatalExit: true})
 
 	var wg sync.WaitGroup

--- a/transports/blank/go.mod
+++ b/transports/blank/go.mod
@@ -5,3 +5,5 @@ go 1.25.0
 replace go.loglayer.dev => ../..
 
 require go.loglayer.dev v0.0.0-00010101000000-000000000000
+
+require github.com/goccy/go-json v0.10.6 // indirect

--- a/transports/blank/go.mod
+++ b/transports/blank/go.mod
@@ -1,0 +1,7 @@
+module go.loglayer.dev/transports/blank
+
+go 1.25.0
+
+replace go.loglayer.dev => ../..
+
+require go.loglayer.dev v0.0.0-00010101000000-000000000000

--- a/transports/blank/go.sum
+++ b/transports/blank/go.sum
@@ -1,0 +1,4 @@
+github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
+github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/transports/slog/go.mod
+++ b/transports/slog/go.mod
@@ -5,3 +5,5 @@ go 1.25.0
 replace go.loglayer.dev => ../..
 
 require go.loglayer.dev v0.0.0-00010101000000-000000000000
+
+require github.com/goccy/go-json v0.10.6 // indirect

--- a/transports/slog/go.mod
+++ b/transports/slog/go.mod
@@ -1,0 +1,7 @@
+module go.loglayer.dev/transports/slog
+
+go 1.25.0
+
+replace go.loglayer.dev => ../..
+
+require go.loglayer.dev v0.0.0-00010101000000-000000000000

--- a/transports/slog/go.sum
+++ b/transports/slog/go.sum
@@ -1,0 +1,4 @@
+github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
+github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=


### PR DESCRIPTION
## Summary

Carves eight previously-bundled sub-packages into their own Go modules so a future breaking change in any one of them no longer cascades into a `go.loglayer.dev/v2` semantic-import-versioning migration. Also rewinds the v2.0.0 release-please entry that triggered this whole refactor — the main module stays at v1.0.2.

## What changed

### Rollback (commit 1)
- `.release-please-manifest.json`: `".": "2.0.0"` → `".": "1.0.2"`
- `CHANGELOG.md`: drop the v2.0.0 section
- (Tag `v2.0.0` and matching GitHub Release were already deleted out-of-band.)

### Eight new sub-modules (commit 2)

| New module | Was bundled in main? | Stdlib only? |
|---|---|---|
| `go.loglayer.dev/plugins/redact` | ✓ | ✓ |
| `go.loglayer.dev/plugins/sampling` | ✓ | ✓ |
| `go.loglayer.dev/plugins/fmtlog` | ✓ | ✓ |
| `go.loglayer.dev/plugins/datadogtrace` | ✓ | ✓ |
| `go.loglayer.dev/integrations/loghttp` | ✓ | ✓ |
| `go.loglayer.dev/integrations/sloghandler` | ✓ | ✓ |
| `go.loglayer.dev/transports/slog` | ✓ | ✓ |
| `go.loglayer.dev/transports/blank` | ✓ | ✓ |

Plus `examples/http-server/` got its own `go.mod` because it imports the now-separated `loghttp` (would otherwise cycle, same pattern as the four pre-existing example modules).

### Stays bundled in main

The four packages whose split would create a require cycle with main's tests/examples — they're imported by the main module's own test code.

| Stays bundled | Imported by main from |
|---|---|
| `transports/console`, `transports/structured` | `example_test.go` (godoc examples) |
| `transports/testing` (lltest) | 11 test files, used as the capture sink |
| `plugins/plugintest` | other plugin tests as a shared test helper |
| `transport/`, `utils/maputil`, `utils/sanitize` | Base helpers used everywhere; low-churn |

### Release-please reconfiguration (commit 3)
Added entries for all eight new packages in `.release-please-config.json` (`packages` map) and `.release-please-manifest.json` (each starting at `"1.0.0"`).

### Documentation (commit 4)
- `<ModuleBadges>` `bundled` flag dropped on the eight split packages' doc pages, so the rendered version badge points at the per-module tag.
- `AGENTS.md` "Multi-module layout" paragraph rewritten with the new bundled-vs-split inventory + reasoning.
- `CHANGELOG.md` preamble: "Three sub-modules" → general note pointing at the manifest as the source of truth.
- `scripts/foreach-module.sh`: append the new modules to `ALL_MODULES`, `SHIPPED_MODULES`, and the `test` op's hardcoded list.
- `plugins/fmtlog.md`: removed the now-stale "ships with the main module" sentence.

### Cross-module test deps (commit 5)
Three cases the split exposed:

1. `transport/concurrency_test.go` imported `transports/blank` → cycle. Switched to `lltest` (transports/testing, staying bundled) for the same role.
2. `integrations/sloghandler` had one test using `plugins/redact` only as a stand-in plugin → not load-bearing, replaced with an inline `loglayer.NewDataHook` (~10 lines, same assertion). `sloghandler/go.mod` no longer references redact.
3. `plugins/datadogtrace/livetest` imports `plugins/datadogtrace` directly. Kept the cross-module dep with explicit `require + replace` because livetest's whole purpose is exercising datadogtrace against a real tracer SDK — the dep is intrinsic.

Plus `go.work` at the repo root (`.gitignore` updated to allow it) so dev tooling sees every module from one place. `go.work.sum` stays ignored.

## Verification done locally

```
$ bash scripts/foreach-module.sh tidy        # clean (no go.mod/go.sum drift)
$ bash scripts/foreach-module.sh build       # all 26 modules build
$ bash scripts/foreach-module.sh test        # all 19 modules with tests pass under -race
$ bash scripts/foreach-module.sh vet         # clean
$ bash scripts/foreach-module.sh fmt         # clean
```

Pre-push race tests passed before upload.

## Post-merge step (required)

The manifest claims each new sub-module is at `v1.0.0`, but no `<component>/v1.0.0` git tag exists yet. Without bootstrap tags, release-please will hit the same "untagged release PR outstanding" abort we saw with v1.0.2. Run after merge:

```sh
git fetch origin
COMMIT=$(git rev-parse origin/main)
for c in plugins/redact plugins/sampling plugins/fmtlog plugins/datadogtrace \
         integrations/loghttp integrations/sloghandler \
         transports/slog transports/blank; do
  git tag "$c/v1.0.0" "$COMMIT"
  gh release create "$c/v1.0.0" --title "$c v1.0.0" --notes "Initial release; package carved out from go.loglayer.dev as an independent module."
done
git push origin --tags
```

## Test plan

- [x] Local race tests, vet, fmt, tidy across all modules
- [x] CI on this PR
- [ ] After merge: run the bootstrap-tag commands above
- [ ] After bootstrap: verify `go get go.loglayer.dev/plugins/redact@v1.0.0` (and others) resolves on `proxy.golang.org`
- [ ] Confirm subsequent merges trigger release-please correctly without aborting

🤖 Generated with [Claude Code](https://claude.com/claude-code)