### PR TITLE
feat(transports/lumberjack): add rotating-file JSON transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,5 @@ go.work.sum
 .env
 
 # Editor/IDE
-# .idea/
+.idea/
 # .vscode/

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -40,6 +40,13 @@
       "include-component-in-tag": true,
       "changelog-path": "CHANGELOG.md"
     },
+    "transports/lumberjack": {
+      "release-type": "go",
+      "package-name": "go.loglayer.dev/transports/lumberjack",
+      "component": "transports/lumberjack",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
     "transports/http": {
       "release-type": "go",
       "package-name": "go.loglayer.dev/transports/http",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,7 @@
   ".": "1.2.0",
   "transports/charmlog": "1.2.0",
   "transports/datadog": "1.2.0",
+  "transports/lumberjack": "1.0.0",
   "transports/http": "1.1.0",
   "transports/logrus": "1.2.0",
   "transports/otellog": "1.2.0",

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -140,6 +140,7 @@ gtag('config', '${gaMeasurementId}');`,
           { text: 'Configuration', link: '/transports/configuration' },
           { text: 'Management', link: '/transports/management' },
           { text: 'Multiple Transports', link: '/transports/multiple-transports' },
+          { text: 'Writers', link: '/transports/writers' },
           { text: 'Creating Transports', link: '/transports/creating-transports' },
           { text: 'Testing Transports', link: '/transports/testing-transports' },
           {
@@ -153,10 +154,16 @@ gtag('config', '${gaMeasurementId}');`,
             ],
           },
           {
-            text: 'Network',
+            text: 'Cloud',
+            items: [
+              { text: 'Datadog', link: '/transports/datadog' },
+            ],
+          },
+          {
+            text: 'Other Transports',
             items: [
               { text: 'HTTP', link: '/transports/http' },
-              { text: 'Datadog', link: '/transports/datadog' },
+              { text: 'File (Lumberjack)', link: '/transports/lumberjack' },
             ],
           },
           {

--- a/docs/src/public/llms-full.txt
+++ b/docs/src/public/llms-full.txt
@@ -29,9 +29,12 @@ go get go.loglayer.dev/transports/logrus
 go get go.loglayer.dev/transports/charmlog
 go get go.loglayer.dev/transports/otellog
 
-# Network shippers
-go get go.loglayer.dev/transports/http
+# Cloud (managed log services)
 go get go.loglayer.dev/transports/datadog
+
+# Other transports
+go get go.loglayer.dev/transports/http
+go get go.loglayer.dev/transports/lumberjack
 
 # Plugins
 go get go.loglayer.dev/plugins/redact
@@ -645,7 +648,32 @@ blank.New(blank.Config{
 })
 ```
 
-## Network Transports
+## Cloud Transports
+
+Managed log services. Async + batched; site-aware where applicable.
+
+### Datadog Transport
+
+Datadog Logs HTTP intake. Site-aware URL, `DD-API-KEY` header, level→status mapping. Built on the HTTP transport.
+
+```go
+import "go.loglayer.dev/transports/datadog"
+
+tr := datadog.New(datadog.Config{
+    APIKey:           os.Getenv("DD_API_KEY"),  // required
+    Site:             datadog.SiteUS3,           // or SiteUS1/EU/AP1, or use URL: ...
+    AllowInsecureURL: false,                     // true to point at httptest.Server
+    Source:           "go",
+    Service:          "checkout-api",
+    Hostname:         hostname,
+    Tags:             "env:prod,team:platform",
+})
+defer tr.Close()
+```
+
+## Other Transports
+
+Generic shippers and on-disk sinks.
 
 ### HTTP Transport
 
@@ -668,24 +696,29 @@ tr := httptr.New(httptr.Config{
 defer tr.Close()  // flush pending entries
 ```
 
-### Datadog Transport
+### File (Lumberjack)
 
-Datadog Logs HTTP intake. Site-aware URL, `DD-API-KEY` header, level→status mapping. Built on the HTTP transport.
+One JSON object per log entry written to a rotating file. Render path matches `transports/structured`. Rotation delegated to `lumberjack.v2`. The package name `lumberjack` shadows the upstream `gopkg.in/natefinch/lumberjack.v2`; alias one of them when both are imported. The shorter `transports/file` import path is reserved for a future rolled-our-own implementation.
 
 ```go
-import "go.loglayer.dev/transports/datadog"
+import "go.loglayer.dev/transports/lumberjack"
 
-tr := datadog.New(datadog.Config{
-    APIKey:           os.Getenv("DD_API_KEY"),  // required
-    Site:             datadog.SiteUS3,           // or SiteUS1/EU/AP1, or use URL: ...
-    AllowInsecureURL: false,                     // true to point at httptest.Server
-    Source:           "go",
-    Service:          "checkout-api",
-    Hostname:         hostname,
-    Tags:             "env:prod,team:platform",
+tr := lumberjack.New(lumberjack.Config{
+    Filename:   "/var/log/myapp/app.log",  // required
+    MaxSize:    100,   // MB before rotation; default 100
+    MaxBackups: 7,     // 0 = keep all (subject to MaxAge)
+    MaxAge:     30,    // days; 0 = no age-based cleanup
+    Compress:   true,  // gzip rotated files
 })
-defer tr.Close()
+defer tr.Close()  // releases file handle; post-Close logs are dropped
+
+// Force rotation (e.g. from a SIGHUP handler):
+_ = tr.Rotate()
 ```
+
+`lumberjack.Build` returns `ErrFilenameRequired` instead of panicking when `Filename` is empty.
+
+To pretty-print to a file, plug `*lumberjack.Logger` directly into the pretty/console transport's `Writer` field — no need for the file transport.
 
 ## Wrapper Transports
 

--- a/docs/src/public/llms.txt
+++ b/docs/src/public/llms.txt
@@ -339,9 +339,12 @@ lines := lib.Lines()  // []lltest.LogLine — assert on Level, Messages, Data, M
 - `transports/testing` — in-memory capture for tests
 - `transports/blank` — user-supplied dispatch function
 
-**Network** (async batched shippers):
-- `transports/http` — generic batched HTTP POST
+**Cloud** (managed log services):
 - `transports/datadog` — Datadog Logs HTTP intake
+
+**Other transports**:
+- `transports/http` — generic batched HTTP POST
+- `transports/lumberjack` — one JSON object per line, rotating file via `lumberjack.v2`
 
 **Wrappers around third-party loggers**:
 - `transports/zerolog`, `transports/zap`, `transports/slog`, `transports/phuslu`, `transports/logrus`, `transports/charmlog`, `transports/otellog`

--- a/docs/src/transports/_partials/transport-list.md
+++ b/docs/src/transports/_partials/transport-list.md
@@ -14,16 +14,28 @@ Self-contained transports that format the entry and write it to an `io.Writer`. 
 
 </div>
 
-### Network
+### Cloud
 
-Transports that ship log entries to a remote endpoint over the network. Async + batched by default.
+Managed log services. Async + batched by default; site-aware where applicable.
+
+<div class="module-list-table">
+
+| Name | Version | Go Reference | Description |
+|------|---------|--------------|-------------|
+| [Datadog](/transports/datadog) | [![Version](https://img.shields.io/github/v/tag/loglayer/loglayer-go?filter=transports/datadog/v*&sort=date&label=version&style=flat-square&color=blue)](https://github.com/loglayer/loglayer-go/releases?q=transports/datadog/&expanded=true) | [![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/datadog.svg)](https://pkg.go.dev/go.loglayer.dev/transports/datadog) | Datadog Logs HTTP intake. Site-aware URL, DD-API-KEY header, status mapping. |
+
+</div>
+
+### Other Transports
+
+Generic shippers and on-disk sinks.
 
 <div class="module-list-table">
 
 | Name | Version | Go Reference | Description |
 |------|---------|--------------|-------------|
 | [HTTP](/transports/http) | [![Version](https://img.shields.io/github/v/tag/loglayer/loglayer-go?filter=transports/http/v*&sort=date&label=version&style=flat-square&color=blue)](https://github.com/loglayer/loglayer-go/releases?q=transports/http/&expanded=true) | [![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/http.svg)](https://pkg.go.dev/go.loglayer.dev/transports/http) | Generic batched HTTP POST to any endpoint. Pluggable Encoder. |
-| [Datadog](/transports/datadog) | [![Version](https://img.shields.io/github/v/tag/loglayer/loglayer-go?filter=transports/datadog/v*&sort=date&label=version&style=flat-square&color=blue)](https://github.com/loglayer/loglayer-go/releases?q=transports/datadog/&expanded=true) | [![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/datadog.svg)](https://pkg.go.dev/go.loglayer.dev/transports/datadog) | Datadog Logs HTTP intake. Site-aware URL, DD-API-KEY header, status mapping. |
+| [File (Lumberjack)](/transports/lumberjack) | [![Version](https://img.shields.io/github/v/tag/loglayer/loglayer-go?filter=transports/lumberjack/v*&sort=date&label=version&style=flat-square&color=blue)](https://github.com/loglayer/loglayer-go/releases?q=transports/lumberjack/&expanded=true) | [![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/lumberjack.svg)](https://pkg.go.dev/go.loglayer.dev/transports/lumberjack) | One JSON object per line written to a rotating file. Backed by `lumberjack.v2`. |
 
 </div>
 

--- a/docs/src/transports/lumberjack.md
+++ b/docs/src/transports/lumberjack.md
@@ -1,0 +1,331 @@
+---
+title: File (Lumberjack)
+description: "One JSON object per log entry written to a rotating file. Backed by lumberjack.v2."
+---
+
+# File (Lumberjack)
+
+<ModuleBadges path="transports/lumberjack" />
+
+The `lumberjack` transport writes one JSON object per log entry to a rotating file on disk. Rotation is handled by [lumberjack.v2](https://github.com/natefinch/lumberjack): size-triggered rollover, configurable backup retention, age-based cleanup, and optional gzip compression. The on-disk format matches [`transports/structured`](/transports/structured) exactly.
+
+```sh
+go get go.loglayer.dev/transports/lumberjack
+```
+
+## Basic Usage
+
+```go
+import (
+    "go.loglayer.dev"
+    "go.loglayer.dev/transports/lumberjack"
+)
+
+log := loglayer.New(loglayer.Config{
+    Transport: lumberjack.New(lumberjack.Config{
+        Filename: "/var/log/myapp/app.log",
+    }),
+})
+
+log.Info("hello")
+// /var/log/myapp/app.log:
+// {"level":"info","time":"2026-04-29T12:00:00Z","msg":"hello"}
+```
+
+`Filename` is required. Use `lumberjack.Build` instead of `lumberjack.New` if the path is loaded at runtime and you want to handle the missing-config case explicitly:
+
+```go
+tr, err := lumberjack.Build(lumberjack.Config{Filename: os.Getenv("LOG_FILE")})
+if errors.Is(err, lumberjack.ErrFilenameRequired) {
+    // fallback: log to stderr instead
+}
+```
+
+## Config
+
+```go
+type Config struct {
+    transport.BaseConfig
+
+    Filename   string                  // required
+    MaxSize    int                     // MB; default 100
+    MaxBackups int                     // 0 = keep all (subject to MaxAge)
+    MaxAge     int                     // days; 0 = no age-based cleanup
+    Compress   bool                    // gzip rotated files
+    LocalTime  bool                    // backup-filename timestamps in local time (default: UTC)
+
+    MessageField string                // default: "msg"
+    DateField    string                // default: "time"
+    LevelField   string                // default: "level"
+    DateFn       func() string
+    LevelFn      func(loglayer.LogLevel) string
+    MessageFn    func(loglayer.TransportParams) string
+
+    OnError func(err error)            // called on write/rotate failure;
+                                       // default writes to os.Stderr
+}
+```
+
+## Rotation
+
+Rotation triggers when the active file's size reaches `MaxSize` megabytes. The current file is renamed with a timestamp suffix and a fresh file is opened at `Filename` for subsequent writes.
+
+```go
+lumberjack.New(lumberjack.Config{
+    Filename:   "/var/log/myapp/app.log",
+    MaxSize:    100,  // rotate at 100 MB
+    MaxBackups: 7,    // keep the 7 most recent backups
+    MaxAge:     30,   // delete backups older than 30 days
+    Compress:   true, // gzip rotated files
+})
+```
+
+After rotation the directory looks like:
+
+```
+app.log              ← active
+app-2026-04-29T03-15-00.000.log.gz
+app-2026-04-28T19-42-11.000.log.gz
+...
+```
+
+`MaxBackups` and `MaxAge` are independent: a file is kept only if it satisfies *both*. Setting both to zero disables cleanup entirely (rotated files accumulate forever).
+
+::: info Lumberjack creates parent directories
+The transport calls into lumberjack, which creates the directory tree for `Filename` on first write. If the parent directory cannot be created (permissions, read-only filesystem), the resulting error surfaces through [`OnError`](#error-handling-onerror).
+:::
+
+## Forcing Rotation: `Rotate()`
+
+Call `Rotate()` to force an immediate roll-over even when `MaxSize` hasn't been reached. The active file is renamed to a timestamped backup and a fresh file is opened at `Filename` for subsequent writes.
+
+```go
+tr := lumberjack.New(lumberjack.Config{Filename: "/var/log/myapp/app.log"})
+
+sigs := make(chan os.Signal, 1)
+signal.Notify(sigs, syscall.SIGHUP)
+go func() {
+    for range sigs {
+        if err := tr.Rotate(); err != nil {
+            // surface to a separate logger, metric, etc.
+        }
+    }
+}()
+```
+
+## Closing the File
+
+`Close()` releases the underlying file handle. After `Close`, subsequent log calls are silently dropped: lumberjack's natural behavior is to lazy-reopen the file on the next write, which would revive the file from a stray late call. The closed flag suppresses that. `Close` is idempotent.
+
+```go
+tr := lumberjack.New(lumberjack.Config{Filename: "/var/log/myapp/app.log"})
+defer tr.Close()
+```
+
+::: warning Close before the process exits
+The transport doesn't buffer entries beyond what the OS does for an open file descriptor, but the OS buffer is per-FD and only fully flushed on `Close`. A process that exits without calling `Close()` may lose the last few writes if the kernel hadn't flushed yet. Wire `Close` into your shutdown path.
+:::
+
+## Error Handling: `OnError`
+
+Writes can fail for ordinary reasons: disk full, permission denied, parent directory removed out from under the open file descriptor, lumberjack failing to rotate. The `OnError` callback surfaces those errors so a failing file sink does not silently swallow log entries.
+
+```go
+tr := lumberjack.New(lumberjack.Config{
+    Filename: "/var/log/myapp/app.log",
+    OnError: func(err error) {
+        metrics.Increment("log.file.write_failures", 1)
+        // Optional: re-log the failure via a different sink so it stays
+        // visible if the file sink is the only thing that's broken.
+        fallback.WithError(err).Error("file transport write failed")
+    },
+})
+```
+
+If `OnError` is nil, a default writes a one-line message to `os.Stderr`. Replace it with a no-op (`func(error) {}`) only if you have a higher-level monitoring path (a sibling transport, an external log shipper, an `OnTransportPanic` handler) catching the failure already.
+
+::: tip Fan out so a file outage doesn't blind you
+Even with `OnError`, the entry that triggered the error is lost. Run a second transport (`pretty`, `structured`, an HTTP shipper) so log lines reach somewhere even when the file sink is down. The `Pretty stdout + JSON file` recipe below is the simplest version.
+:::
+
+## Renaming the Standard Fields
+
+The render-tuning fields (`MessageField`, `DateField`, `LevelField`, `DateFn`, `LevelFn`, `MessageFn`) pass through to the structured renderer; see [Structured Transport](/transports/structured#renaming-the-standard-fields) for examples.
+
+## Direct Access: `GetLoggerInstance`
+
+`Transport.GetLoggerInstance()` returns the underlying `*lumberjack.Logger` so callers can pass it to code that expects a `*lumberjack.Logger` directly (a metrics shipper, a custom rotator-aware utility, etc.). For the everyday operations, the transport already exposes `Rotate()` and `Close()`; you don't need to dive into lumberjack for those.
+
+If you keep a reference to the transport, get it directly. The upstream library and this transport share the package name `lumberjack`, so alias the upstream when you import both.
+
+```go
+import (
+    lj "gopkg.in/natefinch/lumberjack.v2"
+
+    "go.loglayer.dev"
+    "go.loglayer.dev/transports/lumberjack"
+)
+
+tr := lumberjack.New(lumberjack.Config{
+    Filename: "/var/log/myapp/app.log",
+})
+
+rotator := tr.GetLoggerInstance().(*lj.Logger)
+_ = rotator
+```
+
+If you only have the `*loglayer.LogLayer` (e.g. inside a handler that received the logger from elsewhere), look it up by transport ID. This requires assigning a known ID at construction:
+
+```go
+import (
+    lj "gopkg.in/natefinch/lumberjack.v2"
+
+    "go.loglayer.dev"
+    "go.loglayer.dev/transport"
+    "go.loglayer.dev/transports/lumberjack"
+)
+
+log := loglayer.New(loglayer.Config{
+    Transport: lumberjack.New(lumberjack.Config{
+        BaseConfig: transport.BaseConfig{ID: "file"}, // required for lookup-by-ID
+        Filename:   "/var/log/myapp/app.log",
+    }),
+})
+
+// ...later, somewhere only the logger is in scope:
+rotator := log.GetLoggerInstance("file").(*lj.Logger)
+_ = rotator
+```
+
+Without `BaseConfig.ID`, the transport gets an auto-generated identifier and `GetLoggerInstance("file")` returns nil.
+
+## Recipes
+
+### Pretty stdout + JSON file at the same time
+
+Render colorized output to the terminal during interactive runs (via the [Pretty](/transports/pretty) transport) and structured JSON to a rotating file in production, both from one logger. Each transport keeps its own filename, format, and level filter.
+
+```go
+import (
+    "go.loglayer.dev"
+    "go.loglayer.dev/transports/lumberjack"
+    "go.loglayer.dev/transports/pretty"
+)
+
+log := loglayer.New(loglayer.Config{
+    Transports: []loglayer.Transport{
+        pretty.New(pretty.Config{}),
+        lumberjack.New(lumberjack.Config{
+            Filename:   "/var/log/myapp/app.log",
+            MaxSize:    100,
+            MaxBackups: 7,
+            Compress:   true,
+        }),
+    },
+})
+
+log.Info("served")
+// stdout: 12:00:00.000 INFO served   (colorized)
+// /var/log/myapp/app.log: {"level":"info","time":"...","msg":"served"}
+```
+
+### Severity-routed files (info.log + error.log)
+
+A common ops pattern: ship everything to `info.log` and ship errors-only to a smaller, longer-retention `error.log`. Each transport gets every entry; the per-transport `Level` filter keeps each file scoped to its own threshold.
+
+```go
+import (
+    "go.loglayer.dev"
+    "go.loglayer.dev/transport"
+    "go.loglayer.dev/transports/lumberjack"
+)
+
+infoLog := lumberjack.New(lumberjack.Config{
+    BaseConfig: transport.BaseConfig{ID: "info-file"},
+    Filename:   "/var/log/myapp/info.log",
+    MaxSize:    100, MaxBackups: 7, Compress: true,
+})
+errorLog := lumberjack.New(lumberjack.Config{
+    BaseConfig: transport.BaseConfig{
+        ID:    "error-file",
+        Level: loglayer.LogLevelError, // error and fatal only
+    },
+    Filename:   "/var/log/myapp/error.log",
+    MaxSize:    50, MaxBackups: 30, Compress: true, // longer retention
+})
+
+log := loglayer.New(loglayer.Config{
+    Transports: []loglayer.Transport{infoLog, errorLog},
+})
+```
+
+`info.log` ends up with everything at info level and above (including errors). `error.log` contains only the error-and-above subset. To omit info/warn from `info.log` without sending them anywhere, change the logger's own level instead via `loglayer.Config.MinLevel`.
+
+### Daily / time-based rotation
+
+lumberjack rotates on size, not on the clock. For a calendar-aligned roll-over (e.g. a fresh file at 00:00 UTC every day), drive `Rotate()` from a Go ticker.
+
+```go
+import (
+    "time"
+    "go.loglayer.dev/transports/lumberjack"
+)
+
+tr := lumberjack.New(lumberjack.Config{
+    Filename:   "/var/log/myapp/app.log",
+    MaxSize:    1024, // big enough that lumberjack rarely rotates on size
+    MaxBackups: 30,
+    Compress:   true,
+})
+
+go func() {
+    for {
+        now := time.Now().UTC()
+        next := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, time.UTC)
+        time.Sleep(time.Until(next))
+        _ = tr.Rotate()
+    }
+}()
+```
+
+Set `MaxSize` large enough that lumberjack's size-trigger doesn't compete with your daily rotation; `MaxBackups` and `MaxAge` still apply to the rotated files the ticker creates.
+
+### Driving rotation from `logrotate(8)`
+
+If your platform already runs `logrotate(8)`, let it own rotation and use the file transport just to write. Wire SIGHUP to `tr.Rotate()` so the external tool can drive a clean roll-over without restarting the process.
+
+`/etc/logrotate.d/myapp`:
+
+```
+/var/log/myapp/app.log {
+    daily
+    rotate 7
+    compress
+    missingok
+    notifempty
+    sharedscripts
+    postrotate
+        kill -HUP $(cat /var/run/myapp.pid) 2>/dev/null || true
+    endscript
+}
+```
+
+Go side: the SIGHUP handler from [Forcing Rotation](#forcing-rotation-rotate). Set `MaxSize` to a value larger than your daily volume so lumberjack doesn't roll over mid-day on top of `logrotate`'s schedule.
+
+::: warning Don't rely on rename-and-truncate
+Some `logrotate` configurations use `copytruncate` instead of asking the application to reopen its file. That mode is unsafe with this transport: lumberjack holds the file descriptor open, so writes after the truncate land at large offsets in a sparse file, and the rotated copy ends up with the entries you wrote during the rotation window. Use `postrotate` + SIGHUP + `tr.Rotate()` instead.
+:::
+
+## Operational Notes
+
+::: warning No goroutine cleanup on Close
+lumberjack starts a background goroutine the first time it has cleanup work to do (driven by `MaxBackups`, `MaxAge`, or `Compress`). That goroutine has no public stop signal, so it outlives `Close()`. Fine for long-lived processes; tests that construct and tear down many transports leak one goroutine per instance.
+:::
+
+## Fatal Behavior
+
+<!--@include: ./_partials/fatal-passthrough.md-->
+
+## Alternative: Plug Lumberjack Into Other Transports
+
+The `lumberjack` transport is a turnkey wrapper for JSON-to-rotating-file. For pretty-formatted, console-style, or any other render flavor written to a rotating file, plug a `*lumberjack.Logger` into the renderer's `Writer` field directly. See [Rotating file (lumberjack into any renderer)](/transports/writers#rotating-file-lumberjack-into-any-renderer).

--- a/docs/src/transports/structured.md
+++ b/docs/src/transports/structured.md
@@ -79,14 +79,7 @@ log.Warn("loud")
 
 ## Writing to a File or Buffer
 
-```go
-f, _ := os.OpenFile("app.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-log := loglayer.New(loglayer.Config{
-    Transport: structured.New(structured.Config{Writer: f}),
-})
-```
-
-The transport calls `Writer.Write` once per entry with a complete newline-terminated JSON line; make sure your writer is concurrency-safe if multiple goroutines log at once.
+The `Writer` field accepts any `io.Writer`. See [Writers](/transports/writers) for recipes covering files, rotating files, `bytes.Buffer`, `io.MultiWriter`, and network sockets, plus a concurrency-safety table.
 
 ## Struct Metadata
 

--- a/docs/src/transports/writers.md
+++ b/docs/src/transports/writers.md
@@ -1,0 +1,215 @@
+---
+title: Writers
+description: "Plug any io.Writer as the output sink for a renderer transport: files, rotating files, buffers, tees, network sockets."
+---
+
+# Writers
+
+The three renderer transports ([Structured](/transports/structured), [Console](/transports/console), [Pretty](/transports/pretty)) expose a `Writer io.Writer` field on their Config. Whatever satisfies `io.Writer` is a valid output sink. You don't need a custom transport to send entries somewhere new; pick a renderer and plug a writer in.
+
+```go
+log := loglayer.New(loglayer.Config{
+    Transport: structured.New(structured.Config{
+        Writer: anyIoWriter, // os.Stdout, *os.File, *lumberjack.Logger, ...
+    }),
+})
+```
+
+## Defaults
+
+| Transport | Default sink |
+|-----------|-------------|
+| `structured` | `os.Stdout` |
+| `pretty` | `os.Stdout` |
+| `console` | `os.Stdout` for debug/info, `os.Stderr` for warn/error/fatal |
+| `testing` | In-memory; the Writer field is intentionally absent |
+
+## Recipes
+
+### File (basic, no rotation)
+
+```go
+import (
+    "os"
+    "go.loglayer.dev"
+    "go.loglayer.dev/transports/structured"
+)
+
+f, err := os.OpenFile("/var/log/app.log",
+    os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+if err != nil {
+    panic(err)
+}
+defer f.Close()
+
+log := loglayer.New(loglayer.Config{
+    Transport: structured.New(structured.Config{Writer: f}),
+})
+```
+
+The file grows forever. For rotation use [`transports/lumberjack`](/transports/lumberjack) or the lumberjack-as-Writer recipe below.
+
+### Rotating file (lumberjack into any renderer)
+
+The dedicated [lumberjack](/transports/lumberjack) transport already does this for JSON output. Use the recipe below when you want rotation under a non-JSON renderer ([Pretty](/transports/pretty), [Console](/transports/console)).
+
+```go
+import (
+    "gopkg.in/natefinch/lumberjack.v2"
+    "go.loglayer.dev"
+    "go.loglayer.dev/transports/pretty"
+)
+
+rotator := &lumberjack.Logger{
+    Filename:   "/var/log/app.log",
+    MaxSize:    100, // MB
+    MaxBackups: 7,
+    Compress:   true,
+}
+defer rotator.Close()
+
+log := loglayer.New(loglayer.Config{
+    Transport: pretty.New(pretty.Config{Writer: rotator}),
+})
+```
+
+### Tee to multiple sinks
+
+`io.MultiWriter` duplicates writes to every wrapped writer. One transport, one render pass, two destinations.
+
+```go
+import (
+    "io"
+    "os"
+)
+
+log := loglayer.New(loglayer.Config{
+    Transport: structured.New(structured.Config{
+        Writer: io.MultiWriter(os.Stdout, file),
+    }),
+})
+```
+
+::: warning Head-of-line blocking
+`io.MultiWriter` writes to each wrapped writer sequentially in the calling goroutine. A slow sink (e.g. a network connection) blocks every other sink and stalls the caller. Use multiple LogLayer transports if any sink can be slow.
+:::
+
+For finer control (different formats per sink, per-sink level filtering, independent OnError), prefer multiple LogLayer transports instead. See [Multiple Transports](/transports/multiple-transports).
+
+### Buffer (ad-hoc capture)
+
+A `*bytes.Buffer` works but isn't safe for concurrent writes. For real test assertions on log output, use the dedicated [testing transport](/transports/testing) instead, which captures structured `LogLine` values rather than rendered bytes.
+
+```go
+import (
+    "bytes"
+    "go.loglayer.dev"
+    "go.loglayer.dev/transports/structured"
+)
+
+var buf bytes.Buffer
+log := loglayer.New(loglayer.Config{
+    Transport:        structured.New(structured.Config{Writer: &buf}),
+    DisableFatalExit: true,
+})
+
+log.Info("hello")
+// buf.String(): {"level":"info","time":"...","msg":"hello"}
+```
+
+### Network socket (TCP, UDP, syslog)
+
+Anything that satisfies `io.Writer` works, including `net.Conn`. The example below ships one JSON object per line over a plain TCP connection (some syslog daemons accept this directly).
+
+```go
+import (
+    "net"
+    "go.loglayer.dev"
+    "go.loglayer.dev/transports/structured"
+)
+
+conn, err := net.Dial("tcp", "logsink.local:514")
+if err != nil {
+    panic(err)
+}
+defer conn.Close()
+
+log := loglayer.New(loglayer.Config{
+    Transport: structured.New(structured.Config{Writer: conn}),
+})
+```
+
+::: warning Synchronous network writes block the dispatch path
+Each log call blocks until `conn.Write` returns. A slow or unreachable sink stalls the caller's goroutine. For production network shipping use the [HTTP transport](/transports/http) (async batching, configurable buffer, `OnError` callback) or wrap your `net.Conn` in a buffered/async writer of your own.
+:::
+
+### Custom writer with mutation
+
+A `WriterFunc` adapter is sometimes useful for redaction, rate limiting, or sampling. Anything that implements `Write([]byte) (int, error)` works.
+
+```go
+type sampledWriter struct {
+    w    io.Writer
+    keep func() bool
+}
+
+func (s *sampledWriter) Write(p []byte) (int, error) {
+    if !s.keep() {
+        return len(p), nil // pretend we wrote it
+    }
+    return s.w.Write(p)
+}
+```
+
+`keep` runs on every emission across every logging goroutine. Implement it with a lock-free counter (`atomic.Uint64` with modulo, or `math/rand/v2`); a shared `sync.Mutex` would serialize the whole dispatch path.
+
+For dispatch-layer concerns (sampling, redaction, level routing), prefer plugins or a sibling transport with a different Level filter. The Writer layer is the wrong place for anything that depends on the entry's structure.
+
+## Concurrency
+
+Each emission calls `Writer.Write(b)` exactly once with a complete newline-terminated entry. Multiple goroutines logging through the same transport call `Write` concurrently, so the writer must be safe for concurrent use.
+
+| Writer | Concurrent-safe? |
+|--------|----------------|
+| `os.Stdout` / `os.Stderr` / `*os.File` | Yes (each `Write` is one `write(2)` call; short entries don't tear in practice) |
+| `*lumberjack.Logger` | Yes (internal mutex) |
+| `*bytes.Buffer` | No |
+| `net.Conn` (TCP / UDP) | Yes (per Go's `net` docs). TCP writes can interleave at the byte level for entries larger than the kernel send buffer. |
+| `io.MultiWriter` | Only if every wrapped writer is safe |
+
+For unsafe writers, wrap with a mutex:
+
+```go
+type lockedWriter struct {
+    mu sync.Mutex
+    w  io.Writer
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+    l.mu.Lock()
+    defer l.mu.Unlock()
+    return l.w.Write(p)
+}
+```
+
+Don't wrap writers that are already safe (the rows above marked Yes). Adding a second lock around `*os.File` or `*lumberjack.Logger` just serializes the dispatch path with no benefit.
+
+## Wrapper Transports and the `Writer` Field
+
+Wrapper transports ([Zerolog](/transports/zerolog), [Zap](/transports/zap), [logrus](/transports/logrus), [phuslu](/transports/phuslu), [slog](/transports/slog), [charmbracelet/log](/transports/charmlog)) also expose a `Writer` field, but it's a fallback. It's used only when you don't supply a pre-built `Logger`. The right place to configure output for those transports is the underlying logger you pass in:
+
+```go
+import (
+    "github.com/rs/zerolog"
+    "go.loglayer.dev"
+    llzero "go.loglayer.dev/transports/zerolog"
+)
+
+// zerolog: configure on the *zerolog.Logger you build
+z := zerolog.New(rotator).With().Timestamp().Logger()
+log := loglayer.New(loglayer.Config{
+    Transport: llzero.New(llzero.Config{Logger: &z}),
+})
+```
+
+Reach for a wrapper's `Writer` field only when you want a default Logger configured by LogLayer.

--- a/docs/src/whats-new.md
+++ b/docs/src/whats-new.md
@@ -8,6 +8,12 @@ description: Latest features and improvements in LogLayer for Go.
 - [`go.loglayer.dev` Changelog](https://github.com/loglayer/loglayer-go/blob/main/CHANGELOG.md)
 - For users coming from the TypeScript [`loglayer`](https://loglayer.dev) library, see [For TypeScript Developers](/for-typescript-developers) for the API mapping.
 
+## File transport (rotating)
+
+`transports/lumberjack` ships as its own module: one JSON object per log entry, written to a rotating file via [lumberjack.v2](https://github.com/natefinch/lumberjack). Size-triggered rollover, configurable backup retention, age-based cleanup, optional gzip compression, and a `Rotate()` method for SIGHUP-driven roll-overs. See [File (Lumberjack)](/transports/lumberjack).
+
+The `lumberjack` suffix names the rotation backend explicitly so the shorter `transports/file` name stays available for a future rolled-our-own implementation. If you want pretty/console output written to a rotating file today, you don't need this transport. Pass a `*lumberjack.Logger` directly as the `Writer` field of any existing transport.
+
 ## Apr 29, 2026
 
 `v1.0.0`:

--- a/go.work
+++ b/go.work
@@ -7,6 +7,7 @@ use (
 	./transports/charmlog
 	./transports/console
 	./transports/datadog
+	./transports/lumberjack
 	./transports/http
 	./transports/logrus
 	./transports/otellog

--- a/scripts/foreach-module.sh
+++ b/scripts/foreach-module.sh
@@ -19,6 +19,7 @@ ALL_MODULES=(
   transports/charmlog
   transports/console
   transports/datadog
+  transports/lumberjack
   transports/http
   transports/logrus
   transports/otellog
@@ -54,6 +55,7 @@ SHIPPED_MODULES=(
   transports/charmlog
   transports/console
   transports/datadog
+  transports/lumberjack
   transports/http
   transports/logrus
   transports/otellog
@@ -142,6 +144,7 @@ case "$op" in
       transports/charmlog \
       transports/console \
       transports/datadog \
+      transports/lumberjack \
       transports/http \
       transports/logrus \
       transports/otellog \

--- a/transports/lumberjack/CHANGELOG.md
+++ b/transports/lumberjack/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to `go.loglayer.dev/transports/lumberjack` are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+versioning follows [SemVer](https://semver.org/spec/v2.0.0.html).
+
+Releases are managed by [Release Please](https://github.com/googleapis/release-please)
+from conventional commits scoped to `transports/lumberjack`. Tags use the
+prefixed form `transports/lumberjack/v<X.Y.Z>` so this module versions
+independently of the framework core.
+
+## [Unreleased] (target: v1.0.0)
+
+Initial release as a separate Go module.
+
+### Added
+
+- File transport that writes one JSON object per log entry to a rotating file. Rotation is delegated to [lumberjack.v2](https://github.com/natefinch/lumberjack): size-triggered rollover, configurable backup retention, age-based cleanup, and optional gzip compression. Render path matches `transports/structured` so the on-disk format is identical to the structured transport's stdout output.
+- `New` / `Build` constructor pair; `Build` returns `ErrFilenameRequired` instead of panicking when `Config.Filename` is empty.
+- `Config.OnError` callback for write/rotate failures. Default implementation writes a one-line message to `os.Stderr`; pass a custom callback to plumb failures into a logger, alerting pipeline, or metrics counter.
+- `Rotate()` to force an immediate roll-over (e.g. from a SIGHUP handler).
+- `Close()` to release the file handle. Post-close log calls are silently dropped so lumberjack's lazy-reopen does not revive the file.
+- `GetLoggerInstance()` returns the underlying `*lumberjack.Logger` for direct operational access.
+
+[Unreleased]: https://github.com/loglayer/loglayer-go/commits/main/transports/lumberjack

--- a/transports/lumberjack/README.md
+++ b/transports/lumberjack/README.md
@@ -1,0 +1,26 @@
+# go.loglayer.dev/transports/lumberjack
+
+[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/lumberjack.svg)](https://pkg.go.dev/go.loglayer.dev/transports/lumberjack)
+
+File transport for LogLayer with built-in rotation. Writes one JSON object per log entry; rotation is delegated to [lumberjack.v2](https://github.com/natefinch/lumberjack) (size-triggered rollover, backup retention, age-based cleanup, optional gzip compression). On-disk format matches `transports/structured`.
+
+The package name shadows the upstream `gopkg.in/natefinch/lumberjack.v2`. Use an import alias if you import both:
+
+```go
+import (
+    lltransport "go.loglayer.dev/transports/lumberjack"
+    "gopkg.in/natefinch/lumberjack.v2"
+)
+```
+
+## Install
+
+```sh
+go get go.loglayer.dev/transports/lumberjack
+```
+
+## Documentation
+
+Full reference and examples: <https://go.loglayer.dev/transports/lumberjack>
+
+Main library: <https://go.loglayer.dev>

--- a/transports/lumberjack/errors.go
+++ b/transports/lumberjack/errors.go
@@ -1,0 +1,7 @@
+package lumberjack
+
+import "errors"
+
+// ErrFilenameRequired is returned by Build (and panicked by New) when
+// Config.Filename is empty.
+var ErrFilenameRequired = errors.New("loglayer/transports/lumberjack: Config.Filename is required")

--- a/transports/lumberjack/go.mod
+++ b/transports/lumberjack/go.mod
@@ -1,0 +1,15 @@
+module go.loglayer.dev/transports/lumberjack
+
+go 1.25.0
+
+replace go.loglayer.dev => ../..
+
+replace go.loglayer.dev/transports/structured => ../structured
+
+require (
+	go.loglayer.dev v0.0.0-00010101000000-000000000000
+	go.loglayer.dev/transports/structured v0.0.0-00010101000000-000000000000
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+)
+
+require github.com/goccy/go-json v0.10.6 // indirect

--- a/transports/lumberjack/go.sum
+++ b/transports/lumberjack/go.sum
@@ -1,0 +1,6 @@
+github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
+github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=

--- a/transports/lumberjack/lumberjack.go
+++ b/transports/lumberjack/lumberjack.go
@@ -1,0 +1,189 @@
+// Package lumberjack provides a Transport that writes one JSON object
+// per log entry to a rotating file. Rotation is delegated to
+// lumberjack.v2: size-triggered rollover, configurable backup
+// retention, optional gzip compression, and age-based cleanup.
+//
+// The render path is the structured transport's, so the on-disk format
+// matches `transports/structured` exactly. Render-tuning fields
+// (MessageField, DateField, LevelField, DateFn, LevelFn, MessageFn) pass
+// through unchanged.
+//
+// The package name shadows the upstream `gopkg.in/natefinch/lumberjack.v2`
+// (which is also `package lumberjack`); within this file the upstream is
+// aliased to lj. Callers that import both can use a similar alias.
+package lumberjack
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync/atomic"
+
+	lj "gopkg.in/natefinch/lumberjack.v2"
+
+	"go.loglayer.dev"
+	"go.loglayer.dev/transport"
+	"go.loglayer.dev/transports/structured"
+)
+
+// Config holds configuration options for Transport.
+type Config struct {
+	transport.BaseConfig
+
+	// Filename is the file to write logs to. Required.
+	//
+	// Backup files are placed next to the active file with a timestamp
+	// suffix (and optional .gz when Compress is true). Lumberjack creates
+	// the parent directory tree if it does not already exist.
+	Filename string
+
+	// MaxSize is the maximum size in megabytes of the active log file
+	// before it is rotated. Defaults to 100 (lumberjack's default).
+	MaxSize int
+
+	// MaxBackups is the maximum number of rotated files to retain. Older
+	// files are deleted when the count is exceeded. 0 keeps every rotated
+	// file (subject to MaxAge).
+	MaxBackups int
+
+	// MaxAge is the maximum number of days to retain rotated files based
+	// on the timestamp encoded in their filename. 0 disables age-based
+	// cleanup.
+	MaxAge int
+
+	// Compress, when true, gzip-compresses rotated files.
+	Compress bool
+
+	// LocalTime, when true, formats backup-filename timestamps in the
+	// host's local time. Defaults to false (UTC).
+	LocalTime bool
+
+	// MessageField is the JSON key for the joined message text. Defaults
+	// to "msg".
+	MessageField string
+
+	// DateField is the JSON key for the timestamp. Defaults to "time".
+	DateField string
+
+	// LevelField is the JSON key for the log level. Defaults to "level".
+	LevelField string
+
+	// DateFn overrides the default ISO-8601 timestamp.
+	DateFn func() string
+
+	// LevelFn overrides the default level string.
+	LevelFn func(loglayer.LogLevel) string
+
+	// MessageFn formats the message portion. Its return value is used
+	// as the message text.
+	MessageFn func(params loglayer.TransportParams) string
+
+	// OnError is called when a write to the rotating file fails. The
+	// default writes a one-line message to os.Stderr. Use this to plumb
+	// write failures into a separate logger or metrics counter so a
+	// failing file sink does not silence the application.
+	OnError func(error)
+}
+
+// Transport writes one JSON object per log entry to a rotating file.
+type Transport struct {
+	transport.BaseTransport
+	inner   *structured.Transport
+	rotator *lj.Logger
+	closed  atomic.Bool
+}
+
+// New constructs a file Transport.
+//
+// Panics with ErrFilenameRequired when cfg.Filename is empty. Use Build
+// for an error-returning variant when the filename is loaded at runtime
+// (e.g. from configuration or an environment variable).
+func New(cfg Config) *Transport {
+	t, err := Build(cfg)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+// Build constructs a file Transport like New but returns
+// ErrFilenameRequired instead of panicking when cfg.Filename is empty.
+func Build(cfg Config) (*Transport, error) {
+	if cfg.Filename == "" {
+		return nil, ErrFilenameRequired
+	}
+	if cfg.OnError == nil {
+		cfg.OnError = defaultOnError
+	}
+	rot := &lj.Logger{
+		Filename:   cfg.Filename,
+		MaxSize:    cfg.MaxSize,
+		MaxBackups: cfg.MaxBackups,
+		MaxAge:     cfg.MaxAge,
+		Compress:   cfg.Compress,
+		LocalTime:  cfg.LocalTime,
+	}
+	// errorReportingWriter wraps the rotator so lumberjack write errors
+	// surface through cfg.OnError instead of being swallowed by
+	// structured's `_, _ = writer.Write(...)`.
+	inner := structured.New(structured.Config{
+		MessageField: cfg.MessageField,
+		DateField:    cfg.DateField,
+		LevelField:   cfg.LevelField,
+		DateFn:       cfg.DateFn,
+		LevelFn:      cfg.LevelFn,
+		MessageFn:    cfg.MessageFn,
+		Writer:       &errorReportingWriter{w: rot, onError: cfg.OnError},
+	})
+	return &Transport{
+		BaseTransport: transport.NewBaseTransport(cfg.BaseConfig),
+		inner:         inner,
+		rotator:       rot,
+	}, nil
+}
+
+// errorReportingWriter forwards writes to w and reports any error via
+// onError. Without this wrapper, lumberjack write errors would be
+// discarded by the structured renderer.
+type errorReportingWriter struct {
+	w       io.Writer
+	onError func(error)
+}
+
+func (w *errorReportingWriter) Write(p []byte) (int, error) {
+	n, err := w.w.Write(p)
+	if err != nil {
+		w.onError(err)
+	}
+	return n, err
+}
+
+func defaultOnError(err error) {
+	fmt.Fprintf(os.Stderr, "loglayer/transports/lumberjack: write failed: %v\n", err)
+}
+
+// GetLoggerInstance returns the underlying *lumberjack.Logger.
+func (t *Transport) GetLoggerInstance() any { return t.rotator }
+
+func (t *Transport) SendToLogger(params loglayer.TransportParams) {
+	if !t.ShouldProcess(params.LogLevel) {
+		return
+	}
+	t.inner.SendToLogger(params)
+}
+
+// Close releases the underlying file handle and disables the transport
+// so post-Close log calls don't trigger lumberjack's lazy-reopen.
+// Idempotent.
+func (t *Transport) Close() error {
+	if !t.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	t.SetEnabled(false)
+	return t.rotator.Close()
+}
+
+// Rotate forces an immediate rotation of the current log file.
+func (t *Transport) Rotate() error {
+	return t.rotator.Rotate()
+}

--- a/transports/lumberjack/lumberjack_test.go
+++ b/transports/lumberjack/lumberjack_test.go
@@ -1,0 +1,415 @@
+package lumberjack_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"go.loglayer.dev"
+	"go.loglayer.dev/transport"
+	"go.loglayer.dev/transport/transporttest"
+	"go.loglayer.dev/transports/lumberjack"
+)
+
+// readFileBuffer reads path into a *bytes.Buffer so we can reuse the
+// existing transporttest.ParseJSONLine helper.
+func readFileBuffer(t *testing.T, path string) *bytes.Buffer {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return bytes.NewBuffer(data)
+}
+
+func newLogger(t *testing.T, cfg lumberjack.Config) (*loglayer.LogLayer, *lumberjack.Transport, string) {
+	t.Helper()
+	if cfg.Filename == "" {
+		cfg.Filename = filepath.Join(t.TempDir(), "app.log")
+	}
+	if cfg.BaseConfig.ID == "" {
+		cfg.BaseConfig.ID = "file"
+	}
+	tr := lumberjack.New(cfg)
+	t.Cleanup(func() { _ = tr.Close() })
+	log := loglayer.New(loglayer.Config{Transport: tr, DisableFatalExit: true})
+	return log, tr, cfg.Filename
+}
+
+func TestFile_New_PanicsWithoutFilename(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when Filename missing")
+		}
+		err, ok := r.(error)
+		if !ok || !errors.Is(err, lumberjack.ErrFilenameRequired) {
+			t.Errorf("panic value: got %v, want ErrFilenameRequired", r)
+		}
+	}()
+	_ = lumberjack.New(lumberjack.Config{})
+}
+
+func TestFile_Build_ReturnsErrFilenameRequired(t *testing.T) {
+	_, err := lumberjack.Build(lumberjack.Config{})
+	if !errors.Is(err, lumberjack.ErrFilenameRequired) {
+		t.Errorf("Build with missing Filename: got %v, want ErrFilenameRequired", err)
+	}
+}
+
+func TestFile_WritesJSONLine(t *testing.T) {
+	log, tr, path := newLogger(t, lumberjack.Config{})
+	log.Info("hello")
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	obj := transporttest.ParseJSONLine(t, readFileBuffer(t, path))
+	if obj["msg"] != "hello" {
+		t.Errorf("msg: got %v", obj["msg"])
+	}
+	if obj["level"] != "info" {
+		t.Errorf("level: got %v", obj["level"])
+	}
+	if obj["time"] == nil {
+		t.Error("expected time field")
+	}
+}
+
+func TestFile_FieldsAndMetadataMergeAtRoot(t *testing.T) {
+	log, tr, path := newLogger(t, lumberjack.Config{})
+	log.WithFields(loglayer.Fields{"requestId": "abc"}).
+		WithMetadata(loglayer.Metadata{"durationMs": 42}).
+		Info("served")
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	obj := transporttest.ParseJSONLine(t, readFileBuffer(t, path))
+	if obj["requestId"] != "abc" {
+		t.Errorf("requestId: got %v", obj["requestId"])
+	}
+	if obj["durationMs"] != float64(42) {
+		t.Errorf("durationMs: got %v", obj["durationMs"])
+	}
+}
+
+func TestFile_RenameStandardFields(t *testing.T) {
+	log, tr, path := newLogger(t, lumberjack.Config{
+		MessageField: "message",
+		DateField:    "timestamp",
+		LevelField:   "severity",
+	})
+	log.Warn("renamed")
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	obj := transporttest.ParseJSONLine(t, readFileBuffer(t, path))
+	if obj["message"] != "renamed" {
+		t.Errorf("message: got %v", obj["message"])
+	}
+	if obj["severity"] != "warn" {
+		t.Errorf("severity: got %v", obj["severity"])
+	}
+	if obj["timestamp"] == nil {
+		t.Error("expected timestamp field")
+	}
+	if _, dup := obj["msg"]; dup {
+		t.Error("default 'msg' key should be absent when MessageField is overridden")
+	}
+}
+
+func TestFile_LevelFiltering(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.log")
+	tr := lumberjack.New(lumberjack.Config{
+		BaseConfig: transport.BaseConfig{ID: "file", Level: loglayer.LogLevelError},
+		Filename:   path,
+	})
+	t.Cleanup(func() { _ = tr.Close() })
+	log := loglayer.New(loglayer.Config{Transport: tr, DisableFatalExit: true})
+
+	log.Info("dropped")
+	log.Warn("dropped")
+	log.Error("kept")
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	lines := strings.Count(strings.TrimSpace(string(data)), "\n") + 1
+	if lines != 1 {
+		t.Fatalf("expected 1 line after level filter, got %d (content: %q)", lines, data)
+	}
+	obj := transporttest.ParseJSONLine(t, bytes.NewBuffer(data))
+	if obj["msg"] != "kept" {
+		t.Errorf("kept entry msg: got %v", obj["msg"])
+	}
+}
+
+func TestFile_AppendsToExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.log")
+	if err := os.WriteFile(path, []byte("preexisting line\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	log, tr, _ := newLogger(t, lumberjack.Config{Filename: path})
+	log.Info("after")
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.HasPrefix(string(data), "preexisting line\n") {
+		t.Errorf("expected file to start with seeded content, got: %q", data)
+	}
+	if !strings.Contains(string(data), `"msg":"after"`) {
+		t.Errorf("expected appended JSON line, got: %q", data)
+	}
+}
+
+func TestFile_CreatesParentDirectories(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "deeper", "app.log")
+	log, tr, _ := newLogger(t, lumberjack.Config{Filename: path})
+	log.Info("nested")
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected file at %s, got: %v", path, err)
+	}
+}
+
+// MaxSize is in megabytes; setting it to 1 plus a flood of large entries
+// should trigger at least one rotation. Use a generous-but-bounded write
+// loop so the test stays fast.
+func TestFile_RotatesOnSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rotate.log")
+
+	log, tr, _ := newLogger(t, lumberjack.Config{
+		Filename: path,
+		MaxSize:  1, // 1 MB
+	})
+
+	bigPayload := strings.Repeat("x", 10*1024) // 10 KiB per call
+	for i := 0; i < 200; i++ {                 // ~2 MiB written → at least one rotation
+		log.WithMetadata(loglayer.Metadata{"chunk": bigPayload}).Info("flood")
+	}
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) < 2 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("expected at least 2 files (active + 1 backup) after rotation, got %d: %v", len(entries), names)
+	}
+}
+
+// Rotate forces a roll-over even when MaxSize hasn't been reached. The
+// active filename is reused for new writes; the previous content lives
+// in a timestamped backup next to it.
+func TestFile_RotateForcesRollover(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manual.log")
+
+	log, tr, _ := newLogger(t, lumberjack.Config{Filename: path})
+	log.Info("before")
+	if err := tr.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+	log.Info("after")
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) < 2 {
+		t.Fatalf("expected at least 2 files (active + backup), got %d", len(entries))
+	}
+
+	active, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read active: %v", err)
+	}
+	if !strings.Contains(string(active), `"msg":"after"`) {
+		t.Errorf("expected active file to contain post-rotate entry, got: %q", active)
+	}
+	if strings.Contains(string(active), `"msg":"before"`) {
+		t.Errorf("expected pre-rotate entry to live in backup, but found in active: %q", active)
+	}
+}
+
+func TestFile_CloseIsIdempotent(t *testing.T) {
+	_, tr, _ := newLogger(t, lumberjack.Config{})
+	if err := tr.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := tr.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+// After Close, further log calls must not reopen the file. lumberjack's
+// natural behavior is lazy-reopen-on-write; the closed flag suppresses
+// it so termination semantics stay clean.
+func TestFile_PostCloseDropsEntries(t *testing.T) {
+	log, tr, path := newLogger(t, lumberjack.Config{})
+	log.Info("before close")
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	beforeStat, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	beforeSize := beforeStat.Size()
+
+	log.Info("dropped post-close")
+
+	afterStat, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if afterStat.Size() != beforeSize {
+		t.Errorf("expected file size unchanged after Close, got %d → %d", beforeSize, afterStat.Size())
+	}
+}
+
+func TestFile_GetLoggerInstance(t *testing.T) {
+	_, tr, _ := newLogger(t, lumberjack.Config{})
+	got := tr.GetLoggerInstance()
+	if got == nil {
+		t.Fatal("GetLoggerInstance returned nil; expected *lumberjack.Logger")
+	}
+}
+
+// blockWrites pre-creates parent and revokes its write permission so a
+// subsequent OpenFile under it fails with EACCES. The cleanup restores
+// permissions so t.TempDir's own cleanup can remove the tree.
+func blockWrites(t *testing.T) string {
+	t.Helper()
+	if os.Getuid() == 0 {
+		t.Skip("test relies on UID-based permission denial; running as root bypasses DAC")
+	}
+	parent := filepath.Join(t.TempDir(), "locked")
+	if err := os.Mkdir(parent, 0o755); err != nil {
+		t.Fatalf("mkdir parent: %v", err)
+	}
+	if err := os.Chmod(parent, 0o555); err != nil {
+		t.Fatalf("chmod parent: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+	return filepath.Join(parent, "app.log")
+}
+
+// A write failure (lumberjack can't open or rotate the underlying file)
+// must surface via Config.OnError so an unobservable file sink can't
+// silently swallow entries.
+func TestFile_OnErrorFiresOnWriteFailure(t *testing.T) {
+	target := blockWrites(t)
+
+	var calls atomic.Int32
+	var captured atomic.Pointer[error]
+	tr := lumberjack.New(lumberjack.Config{
+		Filename: target,
+		OnError: func(err error) {
+			calls.Add(1)
+			captured.Store(&err)
+		},
+	})
+	t.Cleanup(func() { _ = tr.Close() })
+	log := loglayer.New(loglayer.Config{Transport: tr, DisableFatalExit: true})
+
+	log.Info("trigger write failure")
+
+	if calls.Load() == 0 {
+		t.Fatal("expected OnError to be called at least once")
+	}
+	got := captured.Load()
+	if got == nil || *got == nil {
+		t.Fatal("OnError captured a nil error")
+	}
+}
+
+// Without a user OnError, a write failure must not panic. The default
+// callback writes to stderr; the test verifies the call returns cleanly
+// so a failing sink can't tear down the dispatcher. Stderr output for
+// this one entry is expected and harmless in test output.
+func TestFile_DefaultOnErrorDoesNotPanic(t *testing.T) {
+	target := blockWrites(t)
+
+	tr := lumberjack.New(lumberjack.Config{Filename: target})
+	t.Cleanup(func() { _ = tr.Close() })
+	log := loglayer.New(loglayer.Config{Transport: tr, DisableFatalExit: true})
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("default OnError panicked: %v", r)
+		}
+	}()
+	log.Info("trigger write failure")
+}
+
+// Concurrent writes must not corrupt the on-disk JSON: each line must
+// parse as a complete object. lumberjack.Logger's internal mutex
+// serializes writes; our wrapper adds nothing on the hot path, so this
+// is really a compatibility check that we don't break that property.
+func TestFile_ConcurrentWritesProduceWholeLines(t *testing.T) {
+	log, tr, path := newLogger(t, lumberjack.Config{})
+
+	var wg sync.WaitGroup
+	const goroutines = 8
+	const perGoroutine = 50
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				log.WithMetadata(loglayer.Metadata{"g": g, "i": i}).Info("concurrent")
+			}
+		}(g)
+	}
+	wg.Wait()
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if got, want := len(lines), goroutines*perGoroutine; got != want {
+		t.Fatalf("expected %d lines, got %d", want, got)
+	}
+	for i, line := range lines {
+		obj := transporttest.ParseJSONLine(t, bytes.NewBufferString(line))
+		if obj["msg"] != "concurrent" {
+			t.Errorf("line %d msg: got %v", i, obj["msg"])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- New `transports/lumberjack` sub-module: writes one JSON object per log entry to a rotating file via `gopkg.in/natefinch/lumberjack.v2`. Render path matches `transports/structured` so the on-disk format is byte-identical to the structured transport's stdout output.
- `New` panics with `ErrFilenameRequired` when `Config.Filename` is empty; `Build` returns the error instead. Config exposes lumberjack's rotation knobs (`MaxSize`, `MaxBackups`, `MaxAge`, `Compress`, `LocalTime`) plus the structured render-tuning fields (`MessageField`, `DateField`, `LevelField`, `DateFn`, `LevelFn`, `MessageFn`).
- `Rotate()` for SIGHUP-driven roll-overs. `Close()` releases the file handle and disables the transport so post-Close calls don't trigger lumberjack's lazy-reopen.
- `Config.OnError` callback surfaces write/rotate failures. Default writes a one-line message to stderr; replaceable for metrics/alerting integration.
- New `/transports/writers` page consolidates the "any `io.Writer` is a sink" pattern. Recipes for files, rotating files, `io.MultiWriter`, `bytes.Buffer`, and `net.Conn`, plus a concurrency-safety table and footgun warnings (head-of-line blocking, double-locking, dispatch-path serialization in custom writers).
- Sidebar restructure: old `Network` group becomes `Cloud` (Datadog only); HTTP and the new lumberjack transport move into a new `Other Transports` group.
- Trims the duplicated "Writing to a File or Buffer" recipe in `transports/structured.md` to a one-line link to the new writers page.

The package shadows the upstream `gopkg.in/natefinch/lumberjack.v2` (both are `package lumberjack`); inside our package the upstream is aliased to `lj`, mirroring how `transports/zerolog` handles its collision with `github.com/rs/zerolog` via `zlog`.

## Test plan

- [x] `bash scripts/foreach-module.sh tidy` clean (no go.mod/go.sum drift)
- [x] `bash scripts/foreach-module.sh test` clean across all 30 modules under `-race`
- [x] `bash scripts/foreach-module.sh fmt` and `vet` clean
- [x] `npx vitepress build` clean
- [x] New tests under `-race`: filename validation, JSON shape, fields/metadata at root, custom field names, level filtering, append to existing, parent-dir creation, size-triggered rotation, manual `Rotate()`, idempotent `Close`, post-close drop, `GetLoggerInstance`, concurrent writes preserve whole-line JSON, `OnError` fires on write failure (chmod-locked parent), default OnError doesn't panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)