### PR TITLE
ci: lint commits with the same parser release-please uses

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,60 @@
+name: Commit Lint
+
+# Lints every commit message with the SAME parser release-please uses
+# (@conventional-commits/parser). This catches commits whose body has
+# something the parser can't handle (e.g. a backtick-wrapped function
+# signature with parens) — release-please would silently skip such a
+# commit, so a `feat:` that should trigger a release would land on main
+# without one. The CI failure here surfaces the issue before merge or
+# (on push) immediately after.
+#
+# Local pre-commit equivalent: lefthook's `commit-msg` hook runs the
+# same script on the message you're about to commit.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need history so we can compute the commit range.
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Determine commit range
+        id: range
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "from=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+            echo "to=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            BEFORE="${{ github.event.before }}"
+            # github.event.before is all-zeros on a force-push or first push;
+            # in that case lint just the latest commit.
+            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              echo "from=HEAD~1" >> "$GITHUB_OUTPUT"
+            else
+              echo "from=$BEFORE" >> "$GITHUB_OUTPUT"
+            fi
+            echo "to=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Lint commit messages
+        run: |
+          bun scripts/lint-commit.mjs \
+            --range "${{ steps.range.outputs.from }}..${{ steps.range.outputs.to }}"

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -23,11 +23,15 @@ jobs:
           types: |
             feat
             fix
+            perf
+            revert
+            refactor
+            deps
             docs
             chore
-            refactor
+            style
             test
-            perf
+            build
             ci
           # Scopes are encouraged (e.g. feat(plugins): ...) but not
           # required, since changes to the core have no obvious scope.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,12 +24,18 @@ ln -sf ~/go/bin/lefthook ~/.local/bin/lefthook
 Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 with the package as the scope. The description should be lowercased.
 
-Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `perf`,
-`ci`. Examples:
+Allowed types: `feat`, `fix`, `perf`, `revert`, `refactor`, `deps`, `docs`,
+`chore`, `style`, `test`, `build`, `ci`. Examples:
 
 - `feat(transports/datadog): add eu1 site support`
 - `fix(integrations/loghttp): preserve trailers when wrapping ResponseWriter`
 - `docs: clarify Fields vs Metadata`
+
+The `commit-msg` git hook lints every message with the same parser
+release-please uses (`@conventional-commits/parser`). CI re-runs the
+same check on every PR and on push to main. Run `bun install` once
+after cloning to enable the local hook; without it the hook skips and
+CI is the only safety net.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,51 @@ For detailed documentation, visit [go.loglayer.dev](https://go.loglayer.dev).
 
 Coming from [loglayer for TypeScript](https://loglayer.dev)? See [For TypeScript Developers](https://go.loglayer.dev/for-typescript-developers) for the API mapping and Go-specific differences.
 
+## Local development setup
+
+You need:
+
+| Tool | Why | Install |
+|------|-----|---------|
+| **Go 1.25+** | The main module's floor (`go.mod`). Every sub-module's CI matrix tests against it. | <https://go.dev/dl/> |
+| **lefthook** | Manages the pre-commit, commit-msg, and pre-push git hooks (formatting, vet, conventional-commit lint, race tests). | `go install github.com/evilmartians/lefthook@latest` |
+| **staticcheck** | Pre-commit lint that mirrors what CI runs. Hook fails open if not installed; CI catches anything missed. | `go install honnef.co/go/tools/cmd/staticcheck@latest` |
+| **govulncheck** | Advisory vuln scan (CI runs the same one). Optional; the agent-vulncheck hook prints a hint if it isn't installed. | `go install golang.org/x/vuln/cmd/govulncheck@latest` |
+| **Bun** | Runs `scripts/lint-commit.mjs` (the conventional-commit parser check used by the commit-msg hook) and builds the VitePress docs site under `docs/`. Without bun, the local hook skips and CI catches it. | <https://bun.sh/> |
+
+After cloning:
+
+```sh
+git clone https://github.com/loglayer/loglayer-go
+cd loglayer-go
+
+# Wire up the git hooks (one-time per clone).
+lefthook install
+
+# Install the deps used by the commit-msg hook.
+bun install
+
+# Build everything once to fetch sub-module deps.
+go build ./...
+```
+
+Make sure `$(go env GOPATH)/bin` (default `~/go/bin`) is on your `PATH` so the hooks can find `lefthook` / `staticcheck` / `govulncheck`. If only `~/.local/bin` is on `PATH`, symlink:
+
+```sh
+ln -sf ~/go/bin/lefthook ~/.local/bin/lefthook
+```
+
+Without the symlink (or `PATH` entry), lefthook silently fails open and the hooks won't run.
+
+For docs work:
+
+```sh
+cd docs
+bun install
+bun run docs:build      # validate
+bun run docs:dev        # local preview
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, commit conventions, and PR requirements. Architecture context lives in [AGENTS.md](AGENTS.md).

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,6 +4,26 @@
 # Hooks run automatically on `git commit` (pre-commit) and `git push`
 # (pre-push). Skip a hook for a single command with --no-verify.
 
+commit-msg:
+  commands:
+    # Lint the commit message with the same parser release-please uses
+    # (@conventional-commits/parser). Catches body-parse errors that the
+    # PR-title workflow can't see (which only checks the title). If bun
+    # isn't installed or deps are missing, the script can't run; we
+    # exit 0 with a hint rather than blocking commits — CI will catch
+    # it regardless.
+    conventional-commits:
+      run: |
+        if ! command -v bun >/dev/null 2>&1; then
+          echo "lefthook: bun not on PATH; skipping commit-msg lint (CI will catch any issues). Install bun: https://bun.sh" >&2
+          exit 0
+        fi
+        if [ ! -d node_modules ]; then
+          echo "lefthook: node_modules missing; run 'bun install' to enable the commit-msg lint locally (CI will catch any issues)." >&2
+          exit 0
+        fi
+        bun scripts/lint-commit.mjs --edit {1}
+
 pre-commit:
   parallel: true
   commands:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "loglayer-go-tools",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Repo-level tooling that isn't tied to the docs site (which has its own package.json under docs/). Currently: a commit-message linter that uses the same parser release-please uses, so a commit that breaks release-please's parser fails CI before it can land on main.",
+  "type": "module",
+  "scripts": {
+    "lint-commits": "node scripts/lint-commit.mjs"
+  },
+  "devDependencies": {
+    "@conventional-commits/parser": "^0.4.1"
+  }
+}

--- a/scripts/lint-commit.mjs
+++ b/scripts/lint-commit.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Lints commit messages with @conventional-commits/parser, the exact
+// parser release-please uses. Catches body-parse errors that
+// type-prefix-only checks (and commitlint's default parser) miss.
+//
+// We hit one of those silent skips on PR #19: a backtick-wrapped Go
+// signature in the commit body parsed fine for type detection but
+// blew up release-please's parser, which treated the commit as having
+// no release impact. This script prevents that class of bug.
+//
+// Usage:
+//   node scripts/lint-commit.mjs --range FROM..TO
+//        Lints every commit in the git range.
+//        Used by CI and pre-push.
+//
+//   node scripts/lint-commit.mjs --edit FILE
+//        Lints a single message file (the .git/COMMIT_EDITMSG
+//        path passed by lefthook to the commit-msg hook).
+
+import { parser } from "@conventional-commits/parser";
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+const mode = args[0];
+const value = args[1];
+
+if ((mode !== "--range" && mode !== "--edit") || !value) {
+  console.error("usage: lint-commit.mjs --range FROM..TO");
+  console.error("       lint-commit.mjs --edit FILE");
+  process.exit(2);
+}
+
+function checkOne(message, label) {
+  // Commit-msg hooks see the raw editor content including comment lines
+  // (`# Please enter the commit message...`). Strip them before parsing
+  // so the parser doesn't trip on the leading `#`.
+  const cleaned = message
+    .split("\n")
+    .filter((line) => !line.startsWith("#"))
+    .join("\n")
+    .trim();
+  if (!cleaned) {
+    return true;
+  }
+  try {
+    parser(cleaned);
+    return true;
+  } catch (e) {
+    console.error(`✗ ${label}: ${e.message}`);
+    console.error("---");
+    console.error(cleaned);
+    console.error("---");
+    return false;
+  }
+}
+
+let failed = 0;
+
+if (mode === "--edit") {
+  const message = readFileSync(value, "utf8");
+  if (!checkOne(message, value)) failed++;
+} else {
+  const range = value;
+  const sep = "--END-OF-COMMIT--";
+  const raw = execSync(`git log --format=%H%n%B%n${sep} ${range}`, {
+    encoding: "utf8",
+  });
+  const commits = raw
+    .split(`\n${sep}\n`)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  for (const commit of commits) {
+    const nl = commit.indexOf("\n");
+    const sha = nl === -1 ? commit : commit.slice(0, nl);
+    const message = nl === -1 ? "" : commit.slice(nl + 1);
+    if (!message.trim()) continue;
+    if (!checkOne(message, sha.slice(0, 7))) failed++;
+  }
+}
+
+if (failed > 0) {
+  console.error(
+    `\n${failed} commit(s) failed conventional-commits parse.\n` +
+      `\n` +
+      `release-please uses this same parser. A commit that fails here will\n` +
+      `silently NOT trigger a release, even if its type (feat/fix/etc.) would\n` +
+      `normally bump a version.\n` +
+      `\n` +
+      `Common cause: backtick-wrapped function signatures in the commit body\n` +
+      `containing parens, e.g.\n` +
+      `\n` +
+      `    \`fn(arg)\`  ← parser-unsafe inside backticks early in the body\n` +
+      `    fn(arg)    ← OK\n`
+  );
+  process.exit(1);
+}
+console.error("✓ all commits parsed cleanly");


### PR DESCRIPTION
## Background

PR #19 (the lazy-evaluation feature) merged with a body containing a backtick-wrapped Go signature like `Lazy(fn func() any)` early in the prose. The commit's title is a valid `feat:`, the PR-title workflow accepted it, and `release-please` happily picked it up — until release-please ran the body through `@conventional-commits/parser` and got `unexpected token '(' at 3:23`. release-please **silently** treated it as having no release impact: workflow status `success`, no release-please PR, no version bump. The first signal something went wrong was the missing PR.

## What this PR does

Two-layer safety net using the **exact** parser release-please uses (`@conventional-commits/parser`, not commitlint's older parser).

### CI — `.github/workflows/commit-lint.yml`

Runs on every PR and on push to `main`. Computes the commit range and runs `bun scripts/lint-commit.mjs --range FROM..TO`. Any parse failure fails the workflow.

### Local — `lefthook.yml` `commit-msg` hook

Same script, `--edit MSG_FILE` mode. Fails open if `bun` or `node_modules` are missing so a fresh clone isn't blocked; CI is the hard gate.

### Aligning the type list

The `pr-title.yml` workflow's allowed types now match the full set in `.release-please-config.json` (was missing `revert`, `deps`, `style`, `build`). All 12 conventional types release-please knows about are now accepted.

### Setup docs

- `README.md` gets a new **Local development setup** section listing every required tool (Go, lefthook, staticcheck, govulncheck, bun) with install links and a clone-and-go quickstart.
- `CONTRIBUTING.md` commit-types list aligned and points at the new commit-msg hook.

## Verification

The script catches the exact commit that broke #19:

```
$ bun scripts/lint-commit.mjs --range origin/main~1..origin/main
✗ b3a14da: unexpected token '(' at 3:23, valid tokens [)]
1 commit(s) failed conventional-commits parse.
```

## Test plan

- [x] Script runs cleanly with `bun` (bun-native ESM).
- [x] Script also works under `node` (verified locally during development).
- [x] Local `commit-msg` hook fired on this PR's commit; hook is fail-open when deps aren't installed.
- [x] CI workflow uses `oven-sh/setup-bun@v2` matching the existing docs workflow.
- [x] No `bun.lock` committed; CI does `bun install` and resolves fresh. If you want the lockfile pinned, `bun install` locally and commit `bun.lock` in a follow-up.

## After merge

This PR doesn't fix the *already-orphaned* lazy commit on main — release-please has already evaluated it and skipped it. To get the lazy feature released:

1. Force-push an amended commit message to main with the offending line escaped.
2. Or land a small follow-up `feat:` so release-please re-runs and produces a PR; the lazy commit would still be silently skipped, so its changelog entry would be missing, but main would at least bump.

I'd recommend option (1). Happy to do it after this PR lands so the safety net is in place first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)