### PR TITLE
feat: surface entry groups to transports and dispatch-time plugin hooks

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -44,9 +44,12 @@ jobs:
             echo "to=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
           else
             BEFORE="${{ github.event.before }}"
-            # github.event.before is all-zeros on a force-push or first push;
-            # in that case lint just the latest commit.
-            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            # github.event.before is all-zeros on a first push, and after a
+            # force-push it points at an orphaned SHA that's no longer in
+            # the repo (so `git log BEFORE..HEAD` fails with "Invalid
+            # revision range"). Fall back to HEAD~1 in either case.
+            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ] \
+               || ! git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
               echo "from=HEAD~1" >> "$GITHUB_OUTPUT"
             else
               echo "from=$BEFORE" >> "$GITHUB_OUTPUT"

--- a/dispatch.go
+++ b/dispatch.go
@@ -106,11 +106,13 @@ func (l *LogLayer) processLog(level LogLevel, messages []any, fields Fields, goC
 			Metadata: rawMetadata,
 			Err:      err,
 			Ctx:      goCtx,
+			Groups:   entryGroups,
 		})
 		messages = plugins.runOnBeforeMessageOut(BeforeMessageOutParams{
 			LogLevel: level,
 			Messages: messages,
 			Ctx:      goCtx,
+			Groups:   entryGroups,
 		})
 		level = plugins.runTransformLogLevel(TransformLogLevelParams{
 			LogLevel: level,
@@ -120,6 +122,7 @@ func (l *LogLayer) processLog(level LogLevel, messages []any, fields Fields, goC
 			Metadata: rawMetadata,
 			Err:      err,
 			Ctx:      goCtx,
+			Groups:   entryGroups,
 		})
 	}
 
@@ -131,6 +134,7 @@ func (l *LogLayer) processLog(level LogLevel, messages []any, fields Fields, goC
 		Err:      err,
 		Fields:   fields,
 		Ctx:      goCtx,
+		Groups:   entryGroups,
 	}
 
 	hasShouldSend := plugins.hasSendGate
@@ -153,6 +157,7 @@ func (l *LogLayer) processLog(level LogLevel, messages []any, fields Fields, goC
 			Metadata:    rawMetadata,
 			Err:         err,
 			Ctx:         goCtx,
+			Groups:      entryGroups,
 		}) {
 			continue
 		}

--- a/docs/src/cheatsheet.md
+++ b/docs/src/cheatsheet.md
@@ -248,6 +248,8 @@ loglayer.ActiveGroupsFromEnv("LOGLAYER_GROUPS") // returns []string for Routing.
 
 See [Groups](/logging-api/groups) for the eight-rule routing precedence (defined-but-disabled vs undefined groups, per-group level filtering, ungrouped fallback) and a worked multi-service example.
 
+The merged group set is also surfaced to transports via `TransportParams.Groups` and to all four dispatch-time plugin hooks (`BeforeDataOutParams.Groups`, `BeforeMessageOutParams.Groups`, `TransformLogLevelParams.Groups`, `ShouldSendParams.Groups`) so transports and plugins can read group membership for transformations or wire-payload tagging.
+
 ## Plugins
 
 ```go

--- a/docs/src/plugins/creating-plugins.md
+++ b/docs/src/plugins/creating-plugins.md
@@ -300,6 +300,56 @@ Use it to:
 
 If you need context-aware behavior, use one of the dispatch-time hooks. They fire after every `With*` chain method has run, so the ctx they receive is the same one the transport will see.
 
+## Per-call groups
+
+All four dispatch-time hooks (`DataHook`, `MessageHook`, `LevelHook`, `SendGate`) receive a `Groups []string` field on their params. See [Reading params.Groups](/transports/creating-transports#reading-params-groups) for the slice shape and how routing relates to it; the same rules apply here. Hooks read `Groups` to drive transformations that depend on group membership rather than to make routing choices themselves.
+
+Use it to:
+
+- Promote level for entries in a sensitive group:
+
+  ```go
+  loglayer.NewLevelHook("audit-promotes-warn", func(p loglayer.TransformLogLevelParams) (loglayer.LogLevel, bool) {
+      for _, g := range p.Groups {
+          if g == "audit" && p.LogLevel < loglayer.LogLevelWarn {
+              return loglayer.LogLevelWarn, true
+          }
+      }
+      return 0, false
+  })
+  ```
+
+- Tag the outgoing data with the group set:
+
+  ```go
+  loglayer.NewDataHook("tag-groups", func(p loglayer.BeforeDataOutParams) loglayer.Data {
+      if len(p.Groups) == 0 {
+          return nil
+      }
+      return loglayer.Data{"groups": p.Groups}
+  })
+  ```
+
+- Refine `ShouldSend` beyond what `Routing.Groups` already gates. The dispatch layer drops entries that don't route to a transport before `ShouldSend` runs, so a `SendGate` reading `Groups` is for finer-grained logic (e.g. sample 10% of `audit`-group entries on the shipping transport):
+
+  ```go
+  loglayer.NewSendGate("sample-audit", func(p loglayer.ShouldSendParams) bool {
+      if p.TransportID != "shipping" {
+          return true
+      }
+      for _, g := range p.Groups {
+          if g == "audit" {
+              return rand.Intn(10) == 0
+          }
+      }
+      return true
+  })
+  ```
+
+`MetadataHook` and `FieldsHook` do **not** receive groups. Same reason as `Ctx`: they fire at builder time, before the chain (and the per-call `WithGroup`) is finalized. Group membership isn't determined yet.
+
+`Groups` is shared with the dispatch path; don't mutate it in place.
+
 ## Walking arbitrary inputs
 
 `MetadataHook.OnMetadataCalled` receives `any`. Real call sites pass maps, structs, pointers, slices, and scalars interchangeably. Any plugin that wants to "look inside" the value (redact, sanitize, rename, audit) faces the same problem: handle every shape uniformly without mutating the caller's input.

--- a/docs/src/public/llms-full.txt
+++ b/docs/src/public/llms-full.txt
@@ -845,6 +845,8 @@ func (t *myTransport) SendToLogger(p loglayer.TransportParams) {
 }
 ```
 
+`TransportParams` carries: `LogLevel`, `Messages` (already prefix-applied), `Data` (assembled fields + error map; nil when both absent — use `len(Data) > 0`), `Metadata` (raw `WithMetadata` value; transport decides serialization), `Err`, `Fields` (raw persistent bag), `Ctx` (per-call `WithContext`, nil when unset), `Groups` (merged persistent + per-call `WithGroup` tags; nil when no groups apply — routing has already consumed it before this point, so the slice is exposed for wire-payload tagging only).
+
 The `transport/transporttest` package exports `RunContract(t, ContractCase{...})` — a 14-test contract suite that verifies the wrapper-transport conventions (level filtering, struct vs map metadata, error serialization, fatal handling, etc.).
 
 ## Plugins
@@ -861,6 +863,8 @@ Six lifecycle hooks. A plugin implements any subset of these interfaces:
 | `ShouldSend`        | Per-transport gate; returning false skips that transport for this emission| Sampling, group filtering |
 
 Hook panics are recovered centrally — each hook returns its no-op value on panic, and `ShouldSend` fails open. Set `Plugin.OnError` to observe recovered panics.
+
+The four dispatch-time hook param structs (`BeforeDataOutParams`, `BeforeMessageOutParams`, `TransformLogLevelParams`, `ShouldSendParams`) all carry a `Ctx context.Context` (per-call `WithContext` value, nil if unset) and a `Groups []string` (merged persistent + per-call `WithGroup` tags, nil when none apply). Routing decisions consume `Groups` before any hook fires; the slice is exposed so plugins can drive group-aware transformations. `OnFieldsCalled` and `OnMetadataCalled` fire at builder time (before the chain is finalized) so they don't see either field.
 
 ```go
 log.AddPlugin(loglayer.NewDataHook("tagger", func(p loglayer.BeforeDataOutParams) loglayer.Data {

--- a/docs/src/public/llms.txt
+++ b/docs/src/public/llms.txt
@@ -239,6 +239,8 @@ loglayer.New(loglayer.Config{
 })
 ```
 
+The merged group slice for an entry is also surfaced to transports as `TransportParams.Groups` and to all four dispatch-time plugin hooks (`BeforeDataOutParams.Groups`, `BeforeMessageOutParams.Groups`, `TransformLogLevelParams.Groups`, `ShouldSendParams.Groups`). Use it to ship groups in a transport's wire payload, or to drive group-aware transformations.
+
 ## Child Loggers
 
 ```go

--- a/docs/src/transports/creating-transports.md
+++ b/docs/src/transports/creating-transports.md
@@ -74,10 +74,11 @@ type TransportParams struct {
     Err      error
     Fields   Fields
     Ctx      context.Context // per-call WithContext value, or nil
+    Groups   []string        // merged persistent + per-call WithGroup tags, or nil
 }
 ```
 
-`Data` is the convenience map combining fields + error. `Metadata` is `any`, you choose how to render it. `Err` and `Fields` are also exposed raw if you want to inspect them directly.
+`Data` is the convenience map combining fields + error. `Metadata` is `any`, you choose how to render it. `Err` and `Fields` are also exposed raw if you want to inspect them directly. `Groups` is the merged set of persistent (`WithGroup` on the logger) and per-call (`WithGroup` on the builder) group tags for this entry; it's `nil` when no groups apply.
 
 ## Handling `any` Metadata
 
@@ -156,6 +157,27 @@ Two patterns built-in transports follow:
 - **Self-contained renderers usually ignore it.** Pretty, structured, and console don't read context values themselves; that's a [plugin's](/plugins/creating-plugins) job. If you find yourself extracting trace IDs in a transport, prefer writing a plugin and pairing it with the transport: the plugin runs once per entry and feeds every transport, while transport-side extraction repeats per transport and bypasses the dispatch-time hook ordering.
 
 If your transport extracts values from the context (rather than just forwarding it), test that path with a context that carries a sentinel value and assert the transport surfaced it.
+
+## Reading `params.Groups`
+
+`params.Groups` carries the merged set of group tags for this entry: persistent ones from `log.WithGroup(...)` on the logger, plus per-call ones from `log.WithGroup(...)` on the builder. Persistent tags come first; per-call tags are appended (deduped). The slice is `nil` when no groups apply.
+
+Routing decisions consume groups before the transport sees them: the dispatch layer uses `Groups` to pick which transports an entry goes to, and the slice arrives only after that decision has been made. Read it when your transport ships to a group-aware aggregator that wants the tags as part of the wire payload.
+
+```go
+func (t *Transport) SendToLogger(p loglayer.TransportParams) {
+    if !t.ShouldProcess(p.LogLevel) {
+        return
+    }
+    payload := t.buildPayload(p)
+    if len(p.Groups) > 0 {
+        payload["groups"] = p.Groups
+    }
+    t.send(payload)
+}
+```
+
+`Groups` is shared with the dispatching `*LogLayer`. Don't mutate the slice in place. If you need to reorder, dedupe further, or filter, copy first.
 
 ## Level Filtering
 

--- a/docs/src/whats-new.md
+++ b/docs/src/whats-new.md
@@ -12,6 +12,7 @@ description: Latest features and improvements in LogLayer for Go.
 `loglayer`:
 
 - **Lazy evaluation**: `loglayer.Lazy(fn)` defers value computation in `WithFields` until log dispatch time. The callback runs only when the level passes and re-evaluates on every emission, so expensive work (memory stats, request summaries, large struct serialization) costs nothing on filtered-out entries. Adapted from [LogTape's lazy evaluation](https://logtape.org/manual/lazy). See [Lazy Evaluation](/logging-api/lazy-evaluation).
+- **Groups exposed to transports and plugin hooks**: `TransportParams.Groups` and the four dispatch-time hook param structs (`BeforeDataOutParams`, `BeforeMessageOutParams`, `TransformLogLevelParams`, `ShouldSendParams`) now carry the merged set of persistent and per-call `WithGroup` tags for the entry. Routing decisions still happen before any hook fires; the slice is exposed so transports can ship groups in the wire payload and plugins can drive group-aware data, message, level, or send-gate transformations. Matches the TypeScript loglayer's surface (`LogLayerTransportParams.groups`, `PluginShouldSendToLoggerParams.groups`) and goes beyond it for the other dispatch-time hooks. See [Reading params.Groups](/transports/creating-transports#reading-params-groups) and [Per-call groups](/plugins/creating-plugins#per-call-groups).
 
 `transports/lumberjack`:
 

--- a/go.work
+++ b/go.work
@@ -4,6 +4,7 @@ use (
 	.
 
 	./transports/blank
+	./transports/central
 	./transports/charmlog
 	./transports/console
 	./transports/datadog

--- a/groups_test.go
+++ b/groups_test.go
@@ -3,6 +3,7 @@ package loglayer_test
 import (
 	"errors"
 	"os"
+	"slices"
 	"testing"
 
 	"go.loglayer.dev"
@@ -558,5 +559,53 @@ func TestGroups_WithErrorAndGroupsCompose(t *testing.T) {
 	}
 	if line.Data["err"] == nil {
 		t.Errorf("error should still be present: %v", line.Data)
+	}
+}
+
+// TransportParams.Groups carries the merged persistent + per-call WithGroup
+// tags so transports shipping to a group-aware aggregator can include them
+// in the wire payload.
+func TestGroups_PropagatedToTransportParams(t *testing.T) {
+	cases := []struct {
+		name string
+		emit func(log *loglayer.LogLayer)
+		want [][]string // one slice per emitted line, nil = expect nil Groups
+	}{
+		{
+			name: "per-call",
+			emit: func(log *loglayer.LogLayer) { log.WithGroup("payments", "critical").Info("x") },
+			want: [][]string{{"payments", "critical"}},
+		},
+		{
+			name: "persistent then per-call",
+			emit: func(log *loglayer.LogLayer) {
+				scoped := log.WithGroup("payments")
+				scoped.Info("first")
+				scoped.WithGroup("critical").Warn("second")
+			},
+			want: [][]string{{"payments"}, {"payments", "critical"}},
+		},
+		{
+			name: "nil when WithGroup never called",
+			emit: func(log *loglayer.LogLayer) { log.Info("x") },
+			want: [][]string{nil},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tr, libs := twoTransports("a")
+			log := loglayer.New(loglayer.Config{DisableFatalExit: true, Transports: tr})
+			c.emit(log)
+
+			lines := libs[0].Lines()
+			if len(lines) != len(c.want) {
+				t.Fatalf("expected %d lines, got %d", len(c.want), len(lines))
+			}
+			for i, want := range c.want {
+				if !slices.Equal(lines[i].Groups, want) {
+					t.Errorf("line %d Groups: got %v, want %v", i, lines[i].Groups, want)
+				}
+			}
+		})
 	}
 }

--- a/internal/lltest/lltest.go
+++ b/internal/lltest/lltest.go
@@ -27,6 +27,8 @@ type LogLine struct {
 	Metadata any
 	// Ctx is the per-call context.Context attached via WithContext. Nil if not set.
 	Ctx context.Context
+	// Groups mirrors [loglayer.TransportParams.Groups].
+	Groups []string
 }
 
 // TestLoggingLibrary captures log lines for assertion in tests.
@@ -138,5 +140,6 @@ func (t *TestTransport) SendToLogger(params loglayer.TransportParams) {
 		Data:     params.Data,
 		Metadata: params.Metadata,
 		Ctx:      params.Ctx,
+		Groups:   params.Groups,
 	})
 }

--- a/loglayer.go
+++ b/loglayer.go
@@ -46,6 +46,11 @@ type TransportParams struct {
 	// Transports can use it to extract trace IDs, span context, deadlines, etc.
 	// Nil when no Go context was attached.
 	Ctx context.Context
+	// Groups holds the entry's group tags (persistent WithGroup first,
+	// per-call WithGroup appended, deduped). Nil when no groups apply.
+	// Routing has already consumed the slice before this point; it's
+	// exposed so transports can include it in the wire payload.
+	Groups []string
 }
 
 // transportSet is an immutable snapshot of the transport list and the

--- a/plugin.go
+++ b/plugin.go
@@ -104,6 +104,8 @@ type BeforeDataOutParams struct {
 	Err error
 	// Ctx is the per-call context.Context attached via WithContext, or nil.
 	Ctx context.Context
+	// Groups mirrors [TransportParams.Groups].
+	Groups []string
 }
 
 // BeforeMessageOutParams is the input to [MessageHook.OnBeforeMessageOut].
@@ -112,6 +114,8 @@ type BeforeMessageOutParams struct {
 	Messages []any
 	// Ctx is the per-call context.Context attached via WithContext, or nil.
 	Ctx context.Context
+	// Groups mirrors [TransportParams.Groups].
+	Groups []string
 }
 
 // TransformLogLevelParams is the input to [LevelHook.TransformLogLevel].
@@ -124,6 +128,8 @@ type TransformLogLevelParams struct {
 	Err      error
 	// Ctx is the per-call context.Context attached via WithContext, or nil.
 	Ctx context.Context
+	// Groups mirrors [TransportParams.Groups].
+	Groups []string
 }
 
 // ShouldSendParams is the input to [SendGate.ShouldSend].
@@ -140,6 +146,8 @@ type ShouldSendParams struct {
 	Err         error
 	// Ctx is the per-call context.Context attached via WithContext, or nil.
 	Ctx context.Context
+	// Groups mirrors [TransportParams.Groups].
+	Groups []string
 }
 
 // inner is a private hook the framework uses to see through a wrapper
@@ -358,53 +366,40 @@ func (s *pluginSet) runOnBeforeDataOut(p BeforeDataOutParams) Data {
 	if !s.hasData {
 		return p.Data
 	}
-	out := p.Data
+	// p is by-value; mutate p.Data so each plugin sees the running merge.
 	for i := range s.entries {
 		e := &s.entries[i]
 		if e.onData == nil {
 			continue
 		}
-		patch := callBeforeDataOut(e, BeforeDataOutParams{
-			LogLevel: p.LogLevel,
-			Data:     out,
-			Fields:   p.Fields,
-			Metadata: p.Metadata,
-			Err:      p.Err,
-			Ctx:      p.Ctx,
-		})
-		if patch == nil {
+		patch := callBeforeDataOut(e, p)
+		if len(patch) == 0 {
 			continue
 		}
-		if out == nil {
-			out = make(Data, len(patch))
+		if p.Data == nil {
+			p.Data = make(Data, len(patch))
 		}
 		for k, v := range patch {
-			out[k] = v
+			p.Data[k] = v
 		}
 	}
-	return out
+	return p.Data
 }
 
 func (s *pluginSet) runOnBeforeMessageOut(p BeforeMessageOutParams) []any {
 	if !s.hasMessage {
 		return p.Messages
 	}
-	msgs := p.Messages
 	for i := range s.entries {
 		e := &s.entries[i]
 		if e.onMessage == nil {
 			continue
 		}
-		next := callBeforeMessageOut(e, BeforeMessageOutParams{
-			LogLevel: p.LogLevel,
-			Messages: msgs,
-			Ctx:      p.Ctx,
-		})
-		if next != nil {
-			msgs = next
+		if next := callBeforeMessageOut(e, p); next != nil {
+			p.Messages = next
 		}
 	}
-	return msgs
+	return p.Messages
 }
 
 func (s *pluginSet) runTransformLogLevel(p TransformLogLevelParams) LogLevel {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -3,6 +3,7 @@ package loglayer_test
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -388,6 +389,42 @@ func TestPlugin_DispatchHooksReceiveCtx(t *testing.T) {
 	}
 }
 
+func TestPlugin_DispatchHooksReceiveGroups(t *testing.T) {
+	cases := []struct {
+		name string
+		emit func(log *loglayer.LogLayer)
+		want []string // nil = expect Groups to be nil
+	}{
+		{"with WithGroup", func(log *loglayer.LogLayer) { log.WithGroup("payments", "critical").Info("x") }, []string{"payments", "critical"}},
+		{"without WithGroup", func(log *loglayer.LogLayer) { log.Info("x") }, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var dataGroups, msgGroups, lvlGroups, sendGroups []string
+			log, _ := setup(t)
+			log.AddPlugin(&allHooksGroupsCapture{
+				dataGroups: &dataGroups, msgGroups: &msgGroups,
+				lvlGroups: &lvlGroups, sendGroups: &sendGroups,
+			})
+			c.emit(log)
+
+			for _, h := range []struct {
+				name string
+				got  []string
+			}{
+				{"OnBeforeDataOut", dataGroups},
+				{"OnBeforeMessageOut", msgGroups},
+				{"TransformLogLevel", lvlGroups},
+				{"ShouldSend", sendGroups},
+			} {
+				if !slices.Equal(h.got, c.want) {
+					t.Errorf("%s: Groups got %v, want %v", h.name, h.got, c.want)
+				}
+			}
+		})
+	}
+}
+
 func TestPlugin_ConcurrentAddAndEmit(t *testing.T) {
 	log, _ := setup(t)
 	log.AddPlugin(loglayer.NewMessageHook("always", func(p loglayer.BeforeMessageOutParams) []any {
@@ -752,6 +789,29 @@ func (a *allHooksCtxCapture) TransformLogLevel(p loglayer.TransformLogLevelParam
 }
 func (a *allHooksCtxCapture) ShouldSend(p loglayer.ShouldSendParams) bool {
 	*a.sendCtx = p.Ctx
+	return true
+}
+
+// allHooksGroupsCapture is the Groups counterpart to allHooksCtxCapture.
+type allHooksGroupsCapture struct {
+	dataGroups, msgGroups, lvlGroups, sendGroups *[]string
+}
+
+func (a *allHooksGroupsCapture) ID() string { return "groups-capture" }
+func (a *allHooksGroupsCapture) OnBeforeDataOut(p loglayer.BeforeDataOutParams) loglayer.Data {
+	*a.dataGroups = p.Groups
+	return nil
+}
+func (a *allHooksGroupsCapture) OnBeforeMessageOut(p loglayer.BeforeMessageOutParams) []any {
+	*a.msgGroups = p.Groups
+	return nil
+}
+func (a *allHooksGroupsCapture) TransformLogLevel(p loglayer.TransformLogLevelParams) (loglayer.LogLevel, bool) {
+	*a.lvlGroups = p.Groups
+	return 0, false
+}
+func (a *allHooksGroupsCapture) ShouldSend(p loglayer.ShouldSendParams) bool {
+	*a.sendGroups = p.Groups
 	return true
 }
 

--- a/scripts/foreach-module.sh
+++ b/scripts/foreach-module.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 ALL_MODULES=(
   .
   transports/blank
+  transports/central
   transports/charmlog
   transports/console
   transports/datadog
@@ -52,6 +53,7 @@ ALL_MODULES=(
 SHIPPED_MODULES=(
   .
   transports/blank
+  transports/central
   transports/charmlog
   transports/console
   transports/datadog
@@ -141,6 +143,7 @@ case "$op" in
     for mod in \
       . \
       transports/blank \
+      transports/central \
       transports/charmlog \
       transports/console \
       transports/datadog \

--- a/transports/central/central.go
+++ b/transports/central/central.go
@@ -1,0 +1,161 @@
+// Package central sends log entries to the LogLayer Central log aggregation
+// server's HTTP intake.
+//
+// Wraps transports/http with Central-specific defaults:
+//   - Base URL of http://localhost:9800 (overridable via Config.BaseURL)
+//   - POST to /api/logs as a JSON array
+//   - Encoder that emits Central's expected log shape (service, message,
+//     level, timestamp, instanceId, context, metadata, error, groups, tags)
+//     split out from the assembled fields and per-call metadata
+package central
+
+import (
+	"cmp"
+	"strings"
+
+	"github.com/goccy/go-json"
+
+	"go.loglayer.dev/transport"
+	httptr "go.loglayer.dev/transports/http"
+)
+
+// DefaultPort is the port the Central server listens on by default.
+const DefaultPort = 9800
+
+// DefaultBaseURL is the default base URL for the Central server.
+const DefaultBaseURL = "http://localhost:9800"
+
+// IntakePath is the path appended to the base URL for log ingestion.
+const IntakePath = "/api/logs"
+
+// defaultErrorFieldName mirrors loglayer.Config.ErrorFieldName's default.
+const defaultErrorFieldName = "err"
+
+// Config holds Central transport configuration.
+type Config struct {
+	transport.BaseConfig
+
+	// BaseURL is the base URL of the Central server. Defaults to
+	// "http://localhost:9800". The transport appends "/api/logs" to this
+	// when building the intake URL.
+	BaseURL string
+
+	// Service identifies the source application in the Central server.
+	// Required.
+	Service string
+
+	// InstanceID differentiates between multiple instances of the same
+	// service. Optional.
+	InstanceID string
+
+	// Tags are static tags attached to every entry. Conventionally
+	// key:value strings (e.g. []string{"env:prod", "region:us-east"}).
+	// Optional.
+	Tags []string
+
+	// ErrorFieldName is the key the loglayer core uses for the assembled
+	// error map inside Data. Must match loglayer.Config.ErrorFieldName so
+	// the encoder can lift the error out of "context" and into the
+	// payload's top-level "error" field. Defaults to "err".
+	ErrorFieldName string
+
+	// HTTP overrides batching, client, error handling, and any other
+	// transports/http settings. The URL and Encoder are set by this
+	// package and cannot be overridden via this field.
+	HTTP httptr.Config
+}
+
+// Transport wraps a transports/http.Transport with Central-specific encoding
+// and defaults.
+type Transport struct {
+	*httptr.Transport
+}
+
+// New constructs a Central Transport. Panics if Config.Service is empty.
+// Use Build for an error-returning variant.
+func New(cfg Config) *Transport {
+	t, err := Build(cfg)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+// Build constructs a Central Transport like New but returns
+// ErrServiceRequired instead of panicking when cfg.Service is empty. Use
+// this when the service identifier is loaded at runtime (e.g. from an
+// environment variable) and you want to handle the missing-config case
+// explicitly.
+func Build(cfg Config) (*Transport, error) {
+	if cfg.Service == "" {
+		return nil, ErrServiceRequired
+	}
+	if cfg.HTTP.URL != "" || cfg.HTTP.Encoder != nil {
+		return nil, ErrHTTPOverrideForbidden
+	}
+
+	if cfg.ErrorFieldName == "" {
+		cfg.ErrorFieldName = defaultErrorFieldName
+	}
+
+	httpCfg := cfg.HTTP
+	httpCfg.BaseConfig = cfg.BaseConfig
+	httpCfg.URL = strings.TrimRight(cmp.Or(cfg.BaseURL, DefaultBaseURL), "/") + IntakePath
+	httpCfg.Encoder = newEncoder(cfg)
+
+	httpT, err := httptr.Build(httpCfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Transport{Transport: httpT}, nil
+}
+
+// newEncoder produces the JSON-array encoder for Central's intake format.
+// See TestCentral_PayloadShape for the full per-entry shape.
+func newEncoder(cfg Config) httptr.Encoder {
+	errKey := cfg.ErrorFieldName
+	return httptr.EncoderFunc(func(entries []httptr.Entry) ([]byte, string, error) {
+		objs := make([]map[string]any, len(entries))
+		for i, e := range entries {
+			obj := make(map[string]any, 8)
+			obj["service"] = cfg.Service
+			obj["message"] = transport.JoinMessages(e.Messages)
+			obj["level"] = e.Level.String()
+			obj["timestamp"] = e.Time.UTC().Format("2006-01-02T15:04:05.000Z")
+
+			if cfg.InstanceID != "" {
+				obj["instanceId"] = cfg.InstanceID
+			}
+			if len(e.Groups) > 0 {
+				obj["groups"] = e.Groups
+			}
+			if len(cfg.Tags) > 0 {
+				obj["tags"] = cfg.Tags
+			}
+
+			if errVal, ok := e.Data[errKey]; ok {
+				obj["error"] = errVal
+				if len(e.Data) > 1 {
+					ctx := make(map[string]any, len(e.Data)-1)
+					for k, v := range e.Data {
+						if k == errKey {
+							continue
+						}
+						ctx[k] = v
+					}
+					obj["context"] = ctx
+				}
+			} else if len(e.Data) > 0 {
+				obj["context"] = e.Data
+			}
+
+			if e.Metadata != nil {
+				obj["metadata"] = e.Metadata
+			}
+
+			objs[i] = obj
+		}
+		body, err := json.Marshal(objs)
+		return body, "application/json", err
+	})
+}

--- a/transports/central/central_test.go
+++ b/transports/central/central_test.go
@@ -1,0 +1,428 @@
+package central_test
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"go.loglayer.dev"
+	"go.loglayer.dev/transport"
+	"go.loglayer.dev/transports/central"
+	httptr "go.loglayer.dev/transports/http"
+)
+
+type capture struct {
+	mu      sync.Mutex
+	bodies  [][]byte
+	headers []http.Header
+	paths   []string
+}
+
+func (c *capture) handler(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	c.mu.Lock()
+	c.bodies = append(c.bodies, body)
+	c.headers = append(c.headers, r.Header.Clone())
+	c.paths = append(c.paths, r.URL.Path)
+	c.mu.Unlock()
+	w.WriteHeader(http.StatusOK)
+}
+
+func (c *capture) snapshotBodies() [][]byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([][]byte, len(c.bodies))
+	copy(out, c.bodies)
+	return out
+}
+
+// decodeFirstBatch parses the first captured request body as a JSON array of
+// entries. Fails the test if no body was captured or the body isn't valid JSON.
+func decodeFirstBatch(t *testing.T, c *capture) []map[string]any {
+	t.Helper()
+	bodies := c.snapshotBodies()
+	if len(bodies) == 0 {
+		t.Fatal("no batches captured")
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal(bodies[0], &arr); err != nil {
+		t.Fatalf("body is not JSON: %v: %q", err, bodies[0])
+	}
+	return arr
+}
+
+// newTestCentral spins up an httptest server, builds a central.Transport
+// pointed at it, and wraps it in a loglayer logger. Defaults Service="svc"
+// and a batch large enough that Close drains pending entries (callers that
+// want immediate per-call flushing override HTTP.BatchSize/BatchInterval).
+// The server is closed via t.Cleanup; callers still call tr.Close() before
+// asserting on captured bodies (Close is what drains the worker).
+//
+// cfg.BaseURL is always overwritten with the test server's URL. Tests that
+// need a different BaseURL (e.g. trailing-slash handling) or a non-default
+// loglayer.Config (e.g. custom ErrorFieldName) set up manually instead.
+func newTestCentral(t *testing.T, cfg central.Config) (*loglayer.LogLayer, *central.Transport, *capture) {
+	t.Helper()
+	cap := &capture{}
+	srv := httptest.NewServer(http.HandlerFunc(cap.handler))
+	t.Cleanup(srv.Close)
+
+	if cfg.Service == "" {
+		cfg.Service = "svc"
+	}
+	cfg.BaseURL = srv.URL
+	if cfg.HTTP.BatchSize == 0 {
+		cfg.HTTP.BatchSize = 10
+	}
+	if cfg.HTTP.BatchInterval == 0 {
+		cfg.HTTP.BatchInterval = time.Hour
+	}
+
+	tr := central.New(cfg)
+	log := loglayer.New(loglayer.Config{Transport: tr, DisableFatalExit: true})
+	return log, tr, cap
+}
+
+func TestCentral_Constants(t *testing.T) {
+	if central.DefaultPort != 9800 {
+		t.Errorf("DefaultPort: got %d, want 9800", central.DefaultPort)
+	}
+	if central.DefaultBaseURL != "http://localhost:9800" {
+		t.Errorf("DefaultBaseURL: got %q, want http://localhost:9800", central.DefaultBaseURL)
+	}
+}
+
+func TestCentral_PanicsWithoutService(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when Service missing")
+		}
+		err, ok := r.(error)
+		if !ok || !errors.Is(err, central.ErrServiceRequired) {
+			t.Errorf("panic value: got %v, want ErrServiceRequired", r)
+		}
+	}()
+	_ = central.New(central.Config{})
+}
+
+func TestCentral_Build_ReturnsErrServiceRequired(t *testing.T) {
+	_, err := central.Build(central.Config{})
+	if !errors.Is(err, central.ErrServiceRequired) {
+		t.Errorf("Build with missing Service: got %v, want ErrServiceRequired", err)
+	}
+}
+
+// HTTP.URL and HTTP.Encoder are managed by the central transport itself;
+// setting them via the embedded HTTP config is rejected so silent overrides
+// don't surprise callers.
+func TestCentral_Build_RejectsHTTPOverrides(t *testing.T) {
+	noopEncoder := httptr.EncoderFunc(func(_ []httptr.Entry) ([]byte, string, error) {
+		return nil, "", nil
+	})
+	cases := []struct {
+		name string
+		http httptr.Config
+	}{
+		{"URL set", httptr.Config{URL: "http://my-forwarder.internal/v1/logs"}},
+		{"Encoder set", httptr.Config{Encoder: noopEncoder}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := central.Build(central.Config{Service: "svc", HTTP: c.http})
+			if !errors.Is(err, central.ErrHTTPOverrideForbidden) {
+				t.Errorf("got %v, want ErrHTTPOverrideForbidden", err)
+			}
+		})
+	}
+}
+
+func TestCentral_PostsToBaseURLAPIPath(t *testing.T) {
+	log, tr, cap := newTestCentral(t, central.Config{})
+	log.Info("hello")
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if len(cap.paths) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(cap.paths))
+	}
+	if cap.paths[0] != "/api/logs" {
+		t.Errorf("path: got %q, want /api/logs", cap.paths[0])
+	}
+}
+
+// Trailing slashes on BaseURL must be trimmed before /api/logs is appended,
+// otherwise the URL ends up with a double slash that some intakes reject.
+func TestCentral_TrimsTrailingSlashFromBaseURL(t *testing.T) {
+	cap := &capture{}
+	srv := httptest.NewServer(http.HandlerFunc(cap.handler))
+	t.Cleanup(srv.Close)
+
+	tr := central.New(central.Config{
+		Service: "svc",
+		BaseURL: srv.URL + "/",
+		HTTP:    httptr.Config{BatchSize: 10, BatchInterval: time.Hour},
+	})
+	log := loglayer.New(loglayer.Config{Transport: tr, DisableFatalExit: true})
+	log.Info("hello")
+	_ = tr.Close()
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if len(cap.paths) != 1 || cap.paths[0] != "/api/logs" {
+		t.Errorf("trimmed path: got %v, want /api/logs", cap.paths)
+	}
+}
+
+func TestCentral_PayloadShape(t *testing.T) {
+	log, tr, cap := newTestCentral(t, central.Config{
+		Service:    "test-service",
+		InstanceID: "instance-1",
+		Tags:       []string{"env:test", "team:platform"},
+	})
+	log = log.WithFields(loglayer.Fields{"requestId": "abc"})
+	log.WithMetadata(loglayer.Metadata{"durationMs": 42}).Info("served", "request")
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	cap.mu.Lock()
+	contentType := cap.headers[0].Get("Content-Type")
+	cap.mu.Unlock()
+	if contentType != "application/json" {
+		t.Errorf("Content-Type: got %q, want application/json", contentType)
+	}
+
+	arr := decodeFirstBatch(t, cap)
+	if len(arr) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(arr))
+	}
+	obj := arr[0]
+
+	if obj["service"] != "test-service" {
+		t.Errorf("service: got %v", obj["service"])
+	}
+	if obj["message"] != "served request" {
+		t.Errorf("message: got %v", obj["message"])
+	}
+	if obj["level"] != "info" {
+		t.Errorf("level: got %v", obj["level"])
+	}
+	if obj["instanceId"] != "instance-1" {
+		t.Errorf("instanceId: got %v", obj["instanceId"])
+	}
+
+	tags, ok := obj["tags"].([]any)
+	if !ok {
+		t.Fatalf("tags: got %T, want []any", obj["tags"])
+	}
+	if len(tags) != 2 || tags[0] != "env:test" || tags[1] != "team:platform" {
+		t.Errorf("tags: got %v", tags)
+	}
+
+	ctx, ok := obj["context"].(map[string]any)
+	if !ok {
+		t.Fatalf("context: got %T, want map[string]any", obj["context"])
+	}
+	if ctx["requestId"] != "abc" {
+		t.Errorf("context.requestId: got %v", ctx["requestId"])
+	}
+
+	meta, ok := obj["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata: got %T, want map[string]any", obj["metadata"])
+	}
+	if meta["durationMs"] != float64(42) {
+		t.Errorf("metadata.durationMs: got %v", meta["durationMs"])
+	}
+
+	ts, ok := obj["timestamp"].(string)
+	if !ok || ts == "" {
+		t.Errorf("timestamp: got %v", obj["timestamp"])
+	}
+	if _, err := time.Parse(time.RFC3339Nano, ts); err != nil {
+		t.Errorf("timestamp not parseable as RFC3339: %v (%q)", err, ts)
+	}
+}
+
+func TestCentral_LevelMapping(t *testing.T) {
+	log, tr, cap := newTestCentral(t, central.Config{})
+
+	log.Trace("t")
+	log.Debug("d")
+	log.Info("i")
+	log.Warn("w")
+	log.Error("e")
+	log.Fatal("f")
+	func() {
+		defer func() { _ = recover() }()
+		log.Panic("p")
+	}()
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	arr := decodeFirstBatch(t, cap)
+	want := []string{"trace", "debug", "info", "warn", "error", "fatal", "panic"}
+	if len(arr) != len(want) {
+		t.Fatalf("expected %d entries, got %d", len(want), len(arr))
+	}
+	for i, w := range want {
+		if arr[i]["level"] != w {
+			t.Errorf("entry %d level: got %v, want %s", i, arr[i]["level"], w)
+		}
+	}
+}
+
+func TestCentral_OmitsEmptyOptionalFields(t *testing.T) {
+	log, tr, cap := newTestCentral(t, central.Config{})
+	log.Info("hello") // no fields, no metadata, no error
+	_ = tr.Close()
+
+	arr := decodeFirstBatch(t, cap)
+	for _, key := range []string{"instanceId", "tags", "context", "metadata", "error", "groups"} {
+		if _, present := arr[0][key]; present {
+			t.Errorf("expected %q to be absent when not set, got %v", key, arr[0][key])
+		}
+	}
+}
+
+func TestCentral_ErrorSplitFromContext(t *testing.T) {
+	log, tr, cap := newTestCentral(t, central.Config{})
+	log = log.WithFields(loglayer.Fields{"requestId": "abc"})
+	log.WithError(errors.New("boom")).Error("failed")
+	_ = tr.Close()
+
+	obj := decodeFirstBatch(t, cap)[0]
+
+	errObj, ok := obj["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error: got %T, want map[string]any", obj["error"])
+	}
+	if errObj["message"] != "boom" {
+		t.Errorf("error.message: got %v", errObj["message"])
+	}
+
+	ctx, ok := obj["context"].(map[string]any)
+	if !ok {
+		t.Fatalf("context: got %T, want map[string]any", obj["context"])
+	}
+	if ctx["requestId"] != "abc" {
+		t.Errorf("context.requestId: got %v", ctx["requestId"])
+	}
+	if _, leaked := ctx["err"]; leaked {
+		t.Errorf("context should not contain err key, got %v", ctx)
+	}
+}
+
+// When the only thing in Data is the error map, "context" should be omitted
+// (not emitted as an empty object).
+func TestCentral_ErrorOnly_NoContext(t *testing.T) {
+	log, tr, cap := newTestCentral(t, central.Config{})
+	log.WithError(errors.New("oops")).Error("failed")
+	_ = tr.Close()
+
+	obj := decodeFirstBatch(t, cap)[0]
+	if _, ok := obj["context"]; ok {
+		t.Errorf("expected context to be absent, got %v", obj["context"])
+	}
+	if _, ok := obj["error"]; !ok {
+		t.Errorf("expected error to be present, got %v", obj)
+	}
+}
+
+// When the loglayer core is configured with a non-default ErrorFieldName,
+// the central transport's ErrorFieldName must match for the split to work.
+func TestCentral_CustomErrorFieldName(t *testing.T) {
+	cap := &capture{}
+	srv := httptest.NewServer(http.HandlerFunc(cap.handler))
+	t.Cleanup(srv.Close)
+
+	tr := central.New(central.Config{
+		Service:        "svc",
+		BaseURL:        srv.URL,
+		ErrorFieldName: "error_obj",
+		HTTP:           httptr.Config{BatchSize: 10, BatchInterval: time.Hour},
+	})
+	log := loglayer.New(loglayer.Config{
+		Transport:        tr,
+		ErrorFieldName:   "error_obj",
+		DisableFatalExit: true,
+	})
+	log.WithError(errors.New("boom")).Error("failed")
+	_ = tr.Close()
+
+	obj := decodeFirstBatch(t, cap)[0]
+	if _, ok := obj["error"]; !ok {
+		t.Errorf("expected error to be present, got %v", obj)
+	}
+	if ctx, ok := obj["context"].(map[string]any); ok {
+		if _, leaked := ctx["error_obj"]; leaked {
+			t.Errorf("context should not contain custom error key, got %v", ctx)
+		}
+	}
+}
+
+func TestCentral_GroupsInPayload(t *testing.T) {
+	log, tr, cap := newTestCentral(t, central.Config{})
+	log.WithGroup("payments", "critical").Info("charged")
+	log.Info("plain")
+	_ = tr.Close()
+
+	arr := decodeFirstBatch(t, cap)
+	if len(arr) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(arr))
+	}
+
+	groups, ok := arr[0]["groups"].([]any)
+	if !ok {
+		t.Fatalf("groups: got %T (%v), want []any", arr[0]["groups"], arr[0]["groups"])
+	}
+	if len(groups) != 2 || groups[0] != "payments" || groups[1] != "critical" {
+		t.Errorf("groups: got %v", groups)
+	}
+
+	if _, present := arr[1]["groups"]; present {
+		t.Errorf("entry without WithGroup should omit groups, got %v", arr[1]["groups"])
+	}
+}
+
+func TestCentral_NonMapMetadataPassesThrough(t *testing.T) {
+	log, tr, cap := newTestCentral(t, central.Config{})
+
+	type ev struct {
+		Op string `json:"op"`
+	}
+	log.WithMetadata(ev{Op: "load"}).Info("did")
+	_ = tr.Close()
+
+	obj := decodeFirstBatch(t, cap)[0]
+	meta, ok := obj["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata: got %T (%v), want map[string]any", obj["metadata"], obj["metadata"])
+	}
+	if meta["op"] != "load" {
+		t.Errorf("metadata.op: got %v", meta["op"])
+	}
+}
+
+// BaseConfig.ID must propagate through the central → http wrap so callers
+// can find the transport by ID via loglayer.RemoveTransport / GetLoggerInstance.
+func TestCentral_BaseConfigPropagated(t *testing.T) {
+	tr := central.New(central.Config{
+		BaseConfig: transport.BaseConfig{ID: "central-test"},
+		Service:    "svc",
+	})
+	defer tr.Close()
+	if got := tr.ID(); got != "central-test" {
+		t.Errorf("ID: got %q, want central-test", got)
+	}
+}

--- a/transports/central/errors.go
+++ b/transports/central/errors.go
@@ -1,0 +1,15 @@
+package central
+
+import "errors"
+
+// ErrServiceRequired is returned by Build (and panicked by New) when
+// Config.Service is empty. The Central server uses this field to identify
+// the source application; without it the entry can't be routed.
+var ErrServiceRequired = errors.New("loglayer/transports/central: Config.Service is required")
+
+// ErrHTTPOverrideForbidden is returned by Build (and panicked by New) when
+// Config.HTTP.URL or Config.HTTP.Encoder is non-zero. The Central transport
+// sets these itself (URL from Config.BaseURL, Encoder from this package's
+// Central-format builder); a value supplied via the embedded HTTP config
+// would be silently dropped.
+var ErrHTTPOverrideForbidden = errors.New("loglayer/transports/central: Config.HTTP.URL and Config.HTTP.Encoder are managed by this package and must be left zero")

--- a/transports/central/go.mod
+++ b/transports/central/go.mod
@@ -1,0 +1,14 @@
+module go.loglayer.dev/transports/central
+
+go 1.25.0
+
+replace go.loglayer.dev => ../..
+
+replace go.loglayer.dev/transports/http => ../http
+
+require (
+	github.com/goccy/go-json v0.10.6
+	go.loglayer.dev v0.0.0-00010101000000-000000000000
+	go.loglayer.dev/transports/http v0.0.0-00010101000000-000000000000
+	go.uber.org/goleak v1.3.0
+)

--- a/transports/central/go.sum
+++ b/transports/central/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
+github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/transports/central/goleak_test.go
+++ b/transports/central/goleak_test.go
@@ -1,0 +1,21 @@
+package central_test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain wraps the suite in goleak.VerifyTestMain to catch goroutine
+// leaks. The Central transport spawns an HTTP-style worker for batched
+// shipping; tests must call tr.Close() to shut it down.
+//
+// httptest's connection-shutdown goroutines occasionally outlive the
+// test cleanup, so the http.* persist-conn stacks are filtered out.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m,
+		goleak.IgnoreTopFunction("net/http.(*Server).Shutdown"),
+		goleak.IgnoreAnyFunction("net/http.(*persistConn).readLoop"),
+		goleak.IgnoreAnyFunction("net/http.(*persistConn).writeLoop"),
+	)
+}

--- a/transports/http/http.go
+++ b/transports/http/http.go
@@ -57,6 +57,8 @@ type Entry struct {
 	// Metadata is the raw value the caller passed to WithMetadata. May be a
 	// map, a struct, a scalar, or nil. Encoders decide how to render it.
 	Metadata any
+	// Groups mirrors [loglayer.TransportParams.Groups].
+	Groups []string
 }
 
 // Config holds HTTP transport configuration.
@@ -209,6 +211,7 @@ func (t *Transport) SendToLogger(params loglayer.TransportParams) {
 		Time:     time.Now(),
 		Messages: params.Messages,
 		Metadata: params.Metadata,
+		Groups:   params.Groups,
 	}
 	if len(params.Data) > 0 {
 		entry.Data = params.Data

--- a/transports/http/http_test.go
+++ b/transports/http/http_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -577,5 +578,48 @@ func TestHTTP_DefaultClient_RefusesCrossHostRedirect(t *testing.T) {
 	case got := <-receivedAuth:
 		t.Errorf("X-API-Key leaked to redirected host: %q", got)
 	default:
+	}
+}
+
+// Entry.Groups round-trips from loglayer.TransportParams.Groups so wrapper
+// transports (datadog, central, etc.) can ship groups in the wire payload.
+func TestHTTP_EntryCarriesGroups(t *testing.T) {
+	cap := newCaptureServer()
+	srv := httptest.NewServer(http.HandlerFunc(cap.handler))
+	defer srv.Close()
+
+	var captured [][]string
+	var mu sync.Mutex
+	encoder := httptr.EncoderFunc(func(entries []httptr.Entry) ([]byte, string, error) {
+		mu.Lock()
+		for _, e := range entries {
+			captured = append(captured, append([]string(nil), e.Groups...))
+		}
+		mu.Unlock()
+		return []byte("[]"), "application/json", nil
+	})
+
+	log, tr := newLogger(t, httptr.Config{
+		BatchSize:     10,
+		BatchInterval: time.Hour,
+		Encoder:       encoder,
+	}, srv)
+	log.WithGroup("payments", "critical").Info("charged")
+	log.Info("plain")
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captured) != 2 {
+		t.Fatalf("expected 2 captured entries, got %d", len(captured))
+	}
+	want := []string{"payments", "critical"}
+	if !slices.Equal(captured[0], want) {
+		t.Errorf("entry 0 Groups: got %v, want %v", captured[0], want)
+	}
+	if len(captured[1]) != 0 {
+		t.Errorf("entry 1 Groups: got %v, want nil", captured[1])
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `Groups []string` to `loglayer.TransportParams`, the four dispatch-time hook param structs (`BeforeDataOutParams`, `BeforeMessageOutParams`, `TransformLogLevelParams`, `ShouldSendParams`), `transports/http.Entry`, and `internal/lltest.LogLine`. Routing already consumes the slice before this point; it's exposed for wire-payload tagging and group-driven transformations (level promotion, redaction, sampling).
- Mirrors the TS loglayer surface (`LogLayerTransportParams.groups`, `PluginShouldSendToLoggerParams.groups`) and goes beyond it for the other three dispatch-time hooks (TS doesn't expose groups there).
- Adds a new `transports/central` package wrapping `transports/http` with LogLayer Central server defaults (POST `/api/logs`, JSON array; payload shape: `service`, `message`, `level`, `timestamp`, `instanceId`, `context`, `metadata`, `error`, `groups`, `tags`). **Internal-only for now** — not registered with release-please, no public docs page.
- Eliminates a pre-existing per-plugin params-struct rebuild in `runOnBeforeDataOut` / `runOnBeforeMessageOut` (mutating the by-value local instead of allocating a fresh struct per plugin in the chain).
- CI: `commit-lint.yml` now handles force-pushed `before` SHAs (orphaned refs cause `git log BEFORE..HEAD` to fail with "Invalid revision range"); falls back to `HEAD~1`.

Docs updated: `creating-transports.md` ("Reading params.Groups"), `creating-plugins.md` ("Per-call groups"), `cheatsheet.md`, `whats-new.md`, `llms.txt`, `llms-full.txt`.

## Test plan

- [x] `bash scripts/foreach-module.sh test` (30 modules green under `-race`)
- [x] `bash scripts/foreach-module.sh vet` clean
- [x] `bash scripts/foreach-module.sh fmt` clean
- [x] `cd docs && bun run docs:build` clean
- [x] New tests cover Groups propagation at each layer: `TestGroups_PropagatedToTransportParams` (table-driven, 3 cases), `TestPlugin_DispatchHooksReceiveGroups` (table-driven, 2 cases × 4 hooks), `TestHTTP_EntryCarriesGroups`, `TestCentral_GroupsInPayload`.
- [ ] CI green on this PR (build, vet, test-race, staticcheck, govulncheck, docs-build, commit-lint, pr-title)

🤖 Generated with [Claude Code](https://claude.com/claude-code)