### PR TITLE
docs(getting-started): include transport installs in the install steps

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -9,8 +9,11 @@ LogLayer for Go targets **Go 1.25+** for the main module: `go.loglayer.dev`. Mos
 
 ## Installation
 
+LogLayer ships as a multi-module repo: the core lives at `go.loglayer.dev`, and every transport and plugin is its own independently-versioned sub-module. You install the core plus only the transports you actually use.
+
 ```sh
 go get go.loglayer.dev
+go get go.loglayer.dev/transports/structured
 ```
 
 ## Basic Usage with the Structured Transport
@@ -79,10 +82,15 @@ For stack traces, custom shapes, or other options, see [Error Handling](/logging
 
 If you already have an existing logging stack, LogLayer can wrap it so your call sites use the LogLayer API while emission goes through the underlying logger you've already configured. Here it is for `zerolog`:
 
+```sh
+go get go.loglayer.dev/transports/zerolog github.com/rs/zerolog
+```
+
 ```go
 import (
-    zlog "github.com/rs/zerolog"
     "os"
+
+    zlog "github.com/rs/zerolog"
 
     "go.loglayer.dev"
     llzero "go.loglayer.dev/transports/zerolog"


### PR DESCRIPTION
## Summary

- The Installation section only showed `go get go.loglayer.dev`, but the basic example imports `go.loglayer.dev/transports/structured`. Following the guide top-to-bottom failed with `no required module provides package go.loglayer.dev/transports/structured`.
- The "Using a Logger Wrapper" zerolog example had no install line at all; the reader had to discover both `github.com/rs/zerolog` and `go.loglayer.dev/transports/zerolog` from build errors.
- That example also placed stdlib `os` in the third-party import group; re-grouped it.

Added a one-line note explaining the multi-module layout so the second `go get` doesn't look arbitrary.

## Test plan

- [x] `cd docs && bun run docs:build` passes.
- [x] Walked through the guide end-to-end in a fresh `go mod init` project; basic, error-serializer, and zerolog-wrapper examples all build and run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)