### PR TITLE
ci: parallelize per-module tests and fail-closed on missing hook tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: scripts/foreach-module.sh tidy
 
       - name: Build
-        run: go build ./...
+        run: scripts/foreach-module.sh build
 
       - name: gofmt
         run: scripts/foreach-module.sh fmt
@@ -101,7 +101,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/go/bin/staticcheck
-          key: staticcheck-${{ runner.os }}-go1.26-${{ env.STATICCHECK_VERSION }}
+          key: staticcheck-${{ runner.os }}-${{ env.STATICCHECK_VERSION }}
       - name: Install staticcheck
         if: steps.cache-staticcheck.outputs.cache-hit != 'true'
         run: go install honnef.co/go/tools/cmd/staticcheck@${{ env.STATICCHECK_VERSION }}
@@ -135,7 +135,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/go/bin/govulncheck
-          key: govulncheck-${{ runner.os }}-go1.26-${{ env.GOVULNCHECK_VERSION }}
+          key: govulncheck-${{ runner.os }}-${{ env.GOVULNCHECK_VERSION }}
       - name: Install govulncheck
         if: steps.cache-govulncheck.outputs.cache-hit != 'true'
         run: go install golang.org/x/vuln/cmd/govulncheck@${{ env.GOVULNCHECK_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           cache: true
+          # Default cache key only hashes the root go.sum, which misses
+          # every sub-module's deps. Glob covers them all so a sub-module
+          # bump invalidates the cache (and seeds the new deps into it).
+          cache-dependency-path: '**/go.sum'
 
       - name: Verify modules tidy
         run: scripts/foreach-module.sh tidy
@@ -77,27 +81,63 @@ jobs:
   staticcheck:
     name: Staticcheck
     runs-on: ubuntu-latest
+    env:
+      # Pin instead of @latest so a new staticcheck release with new
+      # checks doesn't surprise CI. Bump deliberately.
+      STATICCHECK_VERSION: '2026.1'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: '1.26'
           cache: true
+          cache-dependency-path: '**/go.sum'
+      # Cache the installed binary keyed on tool + Go version so we skip
+      # `go install`'s recompile on cache hit. Cheap, no third-party action
+      # needed (the official dominikh/staticcheck-action targets single-
+      # module repos and doesn't fit our foreach-module loop).
+      - name: Cache staticcheck binary
+        id: cache-staticcheck
+        uses: actions/cache@v4
+        with:
+          path: ~/go/bin/staticcheck
+          key: staticcheck-${{ runner.os }}-go1.26-${{ env.STATICCHECK_VERSION }}
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+        if: steps.cache-staticcheck.outputs.cache-hit != 'true'
+        run: go install honnef.co/go/tools/cmd/staticcheck@${{ env.STATICCHECK_VERSION }}
+      # Cache staticcheck's own analysis cache so unchanged packages
+      # don't get re-analyzed across runs. This is the bigger of the two
+      # wins; the analysis is what takes time, not the install.
+      - name: Cache staticcheck analysis
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/staticcheck
+          key: staticcheck-cache-${{ runner.os }}-${{ env.STATICCHECK_VERSION }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            staticcheck-cache-${{ runner.os }}-${{ env.STATICCHECK_VERSION }}-
       - name: Run staticcheck
         run: scripts/foreach-module.sh staticcheck
 
   govulncheck:
     name: Govulncheck
     runs-on: ubuntu-latest
+    env:
+      GOVULNCHECK_VERSION: 'v1.1.4'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: '1.26'
           cache: true
+          cache-dependency-path: '**/go.sum'
+      - name: Cache govulncheck binary
+        id: cache-govulncheck
+        uses: actions/cache@v4
+        with:
+          path: ~/go/bin/govulncheck
+          key: govulncheck-${{ runner.os }}-go1.26-${{ env.GOVULNCHECK_VERSION }}
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        if: steps.cache-govulncheck.outputs.cache-hit != 'true'
+        run: go install golang.org/x/vuln/cmd/govulncheck@${{ env.GOVULNCHECK_VERSION }}
       - name: Run govulncheck
         run: scripts/foreach-module.sh vuln

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,12 @@
 # Test binary, built with `go test -c`
 *.test
 
+# Bun deps for the commit-msg lint helper (scripts/lint-commit.mjs).
+# Only docs/ commits its bun.lock; the root project's single tiny dep
+# is re-resolved per-environment by `bun install`.
+/node_modules/
+/bun.lock
+
 # Code coverage profiles and other test artifacts
 *.out
 coverage.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,10 @@ fresh clone won't be blocked while the dev sets up tooling.
 
 Skip a hook for one command with `git commit --no-verify` or
 `git push --no-verify`. Don't make this a habit; the hooks are deliberately
-fast (the full pre-push suite finishes in ~15s).
+fast. The pre-push test step parallelizes the per-module test runs across
+CPUs (override with `PARALLEL=1` to force serial when debugging a single
+module's output), so a typical run finishes in well under 10 seconds on a
+multi-core box.
 
 ## Versioning and Changelog
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,15 +135,23 @@ missing install doesn't break commits).
 
 What runs:
 
+- **commit-msg**: lints the commit message against the same conventional-commits
+  parser release-please uses. Hard-fails if `bun` isn't on PATH or
+  `node_modules` is missing; install bun (https://bun.sh) and run `bun install`.
 - **pre-commit** (parallel): `gofmt -l` on staged Go files (fails if anything
   needs formatting; run `gofmt -w <file>` to fix), `go vet ./...`, and
-  `staticcheck ./...` (skipped with a hint if `staticcheck` isn't on PATH;
-  install once with `go install honnef.co/go/tools/cmd/staticcheck@latest`).
-- **pre-push**: `go test -race -timeout 60s ./...`.
+  `staticcheck ./...`. Hard-fails if `staticcheck` isn't on PATH;
+  install once with `go install honnef.co/go/tools/cmd/staticcheck@latest`.
+- **pre-push**: `go test -race -count=1 ./...` across every module via
+  `scripts/foreach-module.sh test`. The script parallelizes per-module
+  test runs across CPUs; override with `PARALLEL=1` for serial output.
 
-The staticcheck step mirrors what CI runs so a clean pre-commit means a
-clean CI run. The hook fails open when the binary isn't installed, so a
-fresh clone won't be blocked while the dev sets up tooling.
+Hook commands fail closed: missing tooling blocks the commit/push so the
+local checks actually run. Skip a single commit/push with `--no-verify` if
+you genuinely need to. (Note: this only applies to the steps inside
+lefthook.yml. The git hook script lefthook generates still fails open if
+lefthook itself isn't installed; the line below explains why and how to
+recover.)
 
 Skip a hook for one command with `git commit --no-verify` or
 `git push --no-verify`. Don't make this a habit; the hooks are deliberately

--- a/Makefile
+++ b/Makefile
@@ -28,16 +28,16 @@ help: ## Print this help.
 ##@ Build & Test
 
 .PHONY: build
-build: ## Compile every package (sanity check; library has no binary).
-	$(GO) build ./...
+build: ## Build every module (mirrors CI's build step across all sub-modules).
+	scripts/foreach-module.sh build
 
 .PHONY: test
-test: ## Run all tests.
+test: ## Fast main-module tests (no race, no sub-modules). Inner-loop only.
 	$(GO) test ./...
 
 .PHONY: test-race
-test-race: ## Run all tests with the race detector.
-	$(GO) test -race -timeout 60s ./...
+test-race: ## Race tests across every module, parallelized. Mirrors pre-push.
+	scripts/foreach-module.sh test
 
 .PHONY: bench
 bench: ## Run all benchmarks (no tests).
@@ -46,26 +46,31 @@ bench: ## Run all benchmarks (no tests).
 ##@ Lint & Format
 
 .PHONY: vet
-vet: ## go vet over every package.
-	$(GO) vet ./...
+vet: ## go vet across every module.
+	scripts/foreach-module.sh vet
 
 .PHONY: fmt
 fmt: ## Format every Go file in place with gofmt.
 	$(GOFMT) -w $(GO_FILES)
 
 .PHONY: fmt-check
-fmt-check: ## Fail if any Go file is not gofmt-clean.
-	@unformatted="$$($(GOFMT) -l $(GO_FILES))"; \
-	if [ -n "$$unformatted" ]; then \
-		echo "These files are not gofmt-clean:"; \
-		echo "$$unformatted"; \
-		echo; \
-		echo "Run: make fmt"; \
-		exit 1; \
-	fi
+fmt-check: ## Fail if any module has files that aren't gofmt-clean.
+	scripts/foreach-module.sh fmt
+
+.PHONY: tidy
+tidy: ## go mod tidy across every module + diff check (fails on drift).
+	scripts/foreach-module.sh tidy
+
+.PHONY: staticcheck
+staticcheck: ## staticcheck across every shipped module. Same set CI runs.
+	scripts/foreach-module.sh staticcheck
+
+.PHONY: vuln
+vuln: ## govulncheck across every shipped module.
+	scripts/foreach-module.sh vuln
 
 .PHONY: lint
-lint: vet fmt-check ## vet + fmt-check.
+lint: vet fmt-check staticcheck ## vet + fmt-check + staticcheck across every module.
 
 ##@ Docs
 
@@ -92,4 +97,4 @@ livetest-datadog: ## Send a real log to Datadog. Requires DD_API_KEY.
 ##@ CI
 
 .PHONY: ci
-ci: lint test-race ## What CI runs: lint + test-race. Mirror locally before pushing.
+ci: tidy lint test-race ## Full CI gauntlet: tidy + lint + multi-module race tests. Mirror locally before pushing.

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ docs-dev: ## Run the VitePress dev server with live reload.
 hooks: ## Install git pre-commit/pre-push hooks via lefthook.
 	$(LEFTHOOK) install
 
+.PHONY: toc
+toc: ## Regenerate the README table of contents (auto-run by pre-commit).
+	$(BUN) run toc
+
 ##@ Live integration tests
 
 .PHONY: livetest-datadog

--- a/README.md
+++ b/README.md
@@ -69,6 +69,27 @@ log.WithPrefix("[my-app]").
 }
 ```
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of contents
+
+- [Install](#install)
+- [Documentation](#documentation)
+- [TypeScript counterpart](#typescript-counterpart)
+- [Contributing](#contributing)
+  - [Prerequisites](#prerequisites)
+  - [One-time setup](#one-time-setup)
+  - [Repository layout](#repository-layout)
+  - [Common Make targets](#common-make-targets)
+  - [Workflow](#workflow)
+  - [Versioning and stability](#versioning-and-stability)
+  - [Adding a new transport, plugin, or integration](#adding-a-new-transport-plugin-or-integration)
+  - [Docs work](#docs-work)
+- [Issues and questions](#issues-and-questions)
+- [License](#license)
+
+<!-- END doctoc -->
+
 ## Install
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -83,54 +83,105 @@ For detailed documentation, visit [go.loglayer.dev](https://go.loglayer.dev).
 
 Coming from [loglayer for TypeScript](https://loglayer.dev)? See [For TypeScript Developers](https://go.loglayer.dev/for-typescript-developers) for the API mapping and Go-specific differences.
 
-## Local development setup
+## Contributing
 
-You need:
+The user-facing reference is the [docs site](https://go.loglayer.dev). Architectural context (multi-module split, thread-safety contract, performance log, release process) lives in [AGENTS.md](AGENTS.md). Commit conventions and PR requirements are in [CONTRIBUTING.md](CONTRIBUTING.md). This section is the on-ramp for getting a local dev loop running.
+
+### Prerequisites
 
 | Tool | Why | Install |
 |------|-----|---------|
-| **Go 1.25+** | The main module's floor (`go.mod`). Every sub-module's CI matrix tests against it. | <https://go.dev/dl/> |
-| **lefthook** | Manages the pre-commit, commit-msg, and pre-push git hooks (formatting, vet, conventional-commit lint, race tests). | `go install github.com/evilmartians/lefthook@latest` |
-| **staticcheck** | Pre-commit lint that mirrors what CI runs. Hook fails open if not installed; CI catches anything missed. | `go install honnef.co/go/tools/cmd/staticcheck@latest` |
-| **govulncheck** | Advisory vuln scan (CI runs the same one). Optional; the agent-vulncheck hook prints a hint if it isn't installed. | `go install golang.org/x/vuln/cmd/govulncheck@latest` |
-| **Bun** | Runs `scripts/lint-commit.mjs` (the conventional-commit parser check used by the commit-msg hook) and builds the VitePress docs site under `docs/`. Without bun, the local hook skips and CI catches it. | <https://bun.sh/> |
+| Go 1.25+ | Main module floor. CI matrix tests against 1.25 and 1.26. | <https://go.dev/dl/> |
+| lefthook | Drives the pre-commit, commit-msg, and pre-push git hooks. | `go install github.com/evilmartians/lefthook@latest` |
+| staticcheck | Pre-commit lint that mirrors CI. Hook hard-fails without it. | `go install honnef.co/go/tools/cmd/staticcheck@latest` |
+| Bun | Runs the conventional-commit linter and builds the docs site. The commit-msg hook hard-fails without `bun` + `node_modules`. | <https://bun.sh/> |
+| govulncheck (optional) | Advisory vuln scan; the SessionStart hook surfaces findings as session context. | `go install golang.org/x/vuln/cmd/govulncheck@latest` |
 
-After cloning:
-
-```sh
-git clone https://github.com/loglayer/loglayer-go
-cd loglayer-go
-
-# Wire up the git hooks (one-time per clone).
-lefthook install
-
-# Install the deps used by the commit-msg hook.
-bun install
-
-# Build everything once to fetch sub-module deps.
-go build ./...
-```
-
-Make sure `$(go env GOPATH)/bin` (default `~/go/bin`) is on your `PATH` so the hooks can find `lefthook` / `staticcheck` / `govulncheck`. If only `~/.local/bin` is on `PATH`, symlink:
+`go install` puts binaries in `$(go env GOPATH)/bin` (default `~/go/bin`). Make sure that directory is on your `PATH` or the git hooks can't find `lefthook` / `staticcheck`. If only `~/.local/bin` is on your `PATH`, symlink:
 
 ```sh
 ln -sf ~/go/bin/lefthook ~/.local/bin/lefthook
 ```
 
-Without the symlink (or `PATH` entry), lefthook silently fails open and the hooks won't run.
+Without this, the generated git hook script silently fails open (lefthook intentionally exits 0 when it can't find itself) and your local hooks don't run.
 
-For docs work:
+### One-time setup
 
 ```sh
-cd docs
-bun install
-bun run docs:build      # validate
-bun run docs:dev        # local preview
+git clone https://github.com/loglayer/loglayer-go
+cd loglayer-go
+
+make hooks       # wire up git hooks via lefthook
+bun install      # install commit-msg lint deps
+make build       # warm the module cache for every sub-module
 ```
 
-## Contributing
+### Repository layout
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, commit conventions, and PR requirements. Architecture context lives in [AGENTS.md](AGENTS.md).
+This is a multi-module repo. The framework core lives at the root (`go.loglayer.dev`); every transport, plugin, and integration ships as its own independently-versioned Go module so a breaking change in one module bumps only that module's tag namespace, never the whole repo to /v2.
+
+```
+loglayer-go/
+├── *.go                Framework core (loglayer / builder / dispatch / level / ...)
+├── transport/          BaseTransport / BaseConfig + helpers + transporttest
+├── transports/         Built-in transports, one Go module each
+│   ├── pretty/         Colorized terminal output
+│   ├── structured/     JSON-per-line
+│   ├── zerolog/, zap/, charmlog/, logrus/, slog/, ...   Wrappers for popular loggers
+│   ├── otellog/        OpenTelemetry log SDK (split module: heavy deps)
+│   ├── datadog/, http/, sentry/, lumberjack/            Network / file destinations
+│   ├── blank/          Template you can copy when adding a new transport
+│   └── testing/        In-memory capture for tests
+├── plugins/            Built-in plugins (redact, sampling, oteltrace, ...)
+├── integrations/       Higher-level glue (loghttp, sloghandler)
+├── examples/           Runnable example apps, one Go module each
+├── scripts/            CI / dev helpers (foreach-module.sh, agent-vulncheck.sh, ...)
+├── docs/               VitePress docs site (canonical user-facing reference)
+├── go.work             Workspace stitching every sub-module together for gopls
+├── AGENTS.md           Architectural reference; read before non-trivial work
+├── CONTRIBUTING.md     Commit conventions, PR workflow
+└── .claude/rules/      Doc / Go / benchmarking conventions
+```
+
+`go.work` lets `gopls` and `go test ./...` see every module from one place; CI runs each sub-module in isolation through `scripts/foreach-module.sh` so deps don't leak between modules.
+
+### Common Make targets
+
+`make help` lists everything. The ones you'll use most:
+
+| Target | What it does |
+|--------|--------------|
+| `make ci` | Full CI gauntlet: tidy + lint + multi-module race tests. Run before pushing. |
+| `make test-race` | Race tests across every module, parallelized across CPUs. Mirrors pre-push. |
+| `make test` | Fast main-module-only tests for the inner loop. |
+| `make lint` | vet + gofmt-check + staticcheck across every module. |
+| `make fmt` | gofmt every Go file in place. |
+| `make tidy` | `go mod tidy` every sub-module + diff check. |
+| `make staticcheck` / `make vuln` | Run the matching tool across every shipped module. |
+| `make bench` | Run the benchmark suite (`bench_test.go` at repo root). |
+| `make docs` / `make docs-dev` | Build the VitePress docs / run dev server with live reload. |
+
+Behind the scenes, anything multi-module routes through `scripts/foreach-module.sh <op>`. The `test` op accepts `PARALLEL=N` (defaults to `nproc`); set `PARALLEL=1` to serialize when you need clean per-module output for debugging.
+
+### Workflow
+
+- Branch off `main` as `<type>/<short-slug>` (e.g. `feat/zerolog-id`, `docs/getting-started-fixes`).
+- Use [Conventional Commits](https://www.conventionalcommits.org/) with the package as the scope: `feat(transports/zap): add ID field`. The `commit-msg` hook lints with the same parser release-please uses.
+- Hooks run on every commit and push. Don't `--no-verify` past failures; fix the underlying issue. The full pre-push (`make test-race`) finishes in well under 10 seconds on a multi-core box.
+- Don't `git tag` manually. Releases are cut by merging the always-open release-please PR; tags + GitHub Releases happen automatically. See [AGENTS.md → Versioning and Changelog](AGENTS.md) for the full policy.
+
+### Adding a new transport, plugin, or integration
+
+Every transport / plugin ships as its own Go module from day one (no "bundle in main, split later"). `transports/blank/` is a copyable template. The full recipe (go.mod, replace directives, release-please registration, foreach-module updates, docs page) lives in [AGENTS.md → Adding a new transport, plugin, or integration](AGENTS.md). Doc-site conventions for the new page are in [`.claude/rules/documentation.md`](.claude/rules/documentation.md).
+
+### Docs work
+
+```sh
+make docs-dev      # live preview, typically at http://localhost:5173
+make docs          # production build (CI mirrors this)
+```
+
+Source under `docs/src/`. Prose conventions (no em dashes, lead with conclusion, four-page pattern for transports/plugins) are documented in [`.claude/rules/documentation.md`](.claude/rules/documentation.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Source under `docs/src/`. Prose conventions (no em dashes, lead with conclusion,
 
 ## Issues and questions
 
-Bug reports, feature requests, and architectural questions go in [GitHub Issues](https://github.com/loglayer/loglayer-go/issues). Tag the title with the relevant component when applicable (e.g. `[transports/zap]`, `[plugins/redact]`, `[docs]`) so triage is quick.
+Bug reports, feature requests, and architectural questions go in [GitHub Issues](https://github.com/loglayer/loglayer-go/issues).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,13 @@ loglayer-go/
 └── .claude/rules/      Doc / Go / benchmarking conventions
 ```
 
-`go.work` lets `gopls` and `go test ./...` see every module from one place; CI runs each sub-module in isolation through `scripts/foreach-module.sh` so deps don't leak between modules.
+`go.work` is committed and stitches every sub-module together for `gopls` and root-level `go test ./...`. You don't need to run `go work sync` after cloning; everything resolves out of the box. Each sub-module's `go.mod` carries a `replace go.loglayer.dev => ../..` directive (and similar replaces for any sibling sub-modules it depends on) so local edits to the core flow into the sub-modules without publishing. release-please rewrites those replaces to real versions at release time, so you don't manage them by hand. CI runs each sub-module in isolation through `scripts/foreach-module.sh` so deps don't leak between modules.
+
+To run an example app:
+
+```sh
+cd examples/multi-transport && go run .
+```
 
 ### Common Make targets
 
@@ -168,7 +174,12 @@ Behind the scenes, anything multi-module routes through `scripts/foreach-module.
 - Branch off `main` as `<type>/<short-slug>` (e.g. `feat/zerolog-id`, `docs/getting-started-fixes`).
 - Use [Conventional Commits](https://www.conventionalcommits.org/) with the package as the scope: `feat(transports/zap): add ID field`. The `commit-msg` hook lints with the same parser release-please uses.
 - Hooks run on every commit and push. Don't `--no-verify` past failures; fix the underlying issue. The full pre-push (`make test-race`) finishes in well under 10 seconds on a multi-core box.
-- Don't `git tag` manually. Releases are cut by merging the always-open release-please PR; tags + GitHub Releases happen automatically. See [AGENTS.md → Versioning and Changelog](AGENTS.md) for the full policy.
+
+### Versioning and stability
+
+Each module follows SemVer from `v1.0.0` onward. The framework core (`go.loglayer.dev`) and every transport / plugin / integration are versioned independently, so a breaking change in (say) `transports/zap` bumps that module's tag namespace alone (`transports/zap/v2.0.0`) and doesn't force you off the latest core. `feat:` → minor, `fix:` → patch, `feat!:` or a body containing `BREAKING CHANGE:` → major.
+
+Releases are cut by merging the always-open release-please PR; tags + GitHub Releases happen automatically. Don't `git tag` manually. Full policy: [AGENTS.md → Versioning and Changelog](AGENTS.md).
 
 ### Adding a new transport, plugin, or integration
 
@@ -182,6 +193,10 @@ make docs          # production build (CI mirrors this)
 ```
 
 Source under `docs/src/`. Prose conventions (no em dashes, lead with conclusion, four-page pattern for transports/plugins) are documented in [`.claude/rules/documentation.md`](.claude/rules/documentation.md).
+
+## Issues and questions
+
+Bug reports, feature requests, and architectural questions go in [GitHub Issues](https://github.com/loglayer/loglayer-go/issues). Tag the title with the relevant component when applicable (e.g. `[transports/zap]`, `[plugins/redact]`, `[docs]`) so triage is quick.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Behind the scenes, anything multi-module routes through `scripts/foreach-module.
 
 ### Adding a new transport, plugin, or integration
 
-Every transport / plugin ships as its own Go module from day one (no "bundle in main, split later"). `transports/blank/` is a copyable template. The full recipe (go.mod, replace directives, release-please registration, foreach-module updates, docs page) lives in [AGENTS.md → Adding a new transport, plugin, or integration](AGENTS.md). Doc-site conventions for the new page are in [`.claude/rules/documentation.md`](.claude/rules/documentation.md).
+Every transport / plugin / integration ships as its own Go module from day one (no "bundle in main, split later"). `transports/blank/` is a copyable template. The full recipe (go.mod, replace directives, release-please registration, foreach-module updates, docs page) lives in [AGENTS.md → Adding a new transport, plugin, or integration](AGENTS.md). Doc-site conventions for the new page are in [`.claude/rules/documentation.md`](.claude/rules/documentation.md).
 
 ### Docs work
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,13 +7,13 @@
 commit-msg:
   commands:
     # Lint the commit message with the same parser release-please uses
-    # (@conventional-commits/parser). Catches body-parse errors that the
+    # (@conventional-commits/parser). Catches body-parse errors the
     # PR-title workflow can't see (which only checks the title).
     #
-    # Missing tooling is a hard fail (was previously fail-open with an
-    # "CI will catch it" hint, but that defeated the purpose of the
-    # local hook). Skip per-commit with --no-verify if you genuinely
-    # need to bypass it.
+    # Missing tooling is a hard fail: the local hook only matters if it
+    # actually runs, and a silent skip ships "works on my machine"
+    # commits that fail in CI on someone else's box. Bypass per-commit
+    # with --no-verify if you genuinely need to.
     conventional-commits:
       run: |
         if ! command -v bun >/dev/null 2>&1; then
@@ -39,10 +39,9 @@ pre-commit:
       glob: "*.go"
       run: go vet ./...
     # Mirror what CI runs so a clean pre-commit means a clean CI run.
-    # Hard-fails if staticcheck isn't installed (was previously fail-open
-    # with a hint, but that meant first-time clones could land breaking
-    # changes that only failed on CI). Skip per-commit with --no-verify
-    # if you need to.
+    # Hard-fails if staticcheck isn't installed: the lint should actually
+    # run before the commit lands, not be deferred to CI on a clone where
+    # the tool happens to be missing. Bypass per-commit with --no-verify.
     staticcheck:
       glob: "*.go"
       run: |

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,19 +8,21 @@ commit-msg:
   commands:
     # Lint the commit message with the same parser release-please uses
     # (@conventional-commits/parser). Catches body-parse errors that the
-    # PR-title workflow can't see (which only checks the title). If bun
-    # isn't installed or deps are missing, the script can't run; we
-    # exit 0 with a hint rather than blocking commits — CI will catch
-    # it regardless.
+    # PR-title workflow can't see (which only checks the title).
+    #
+    # Missing tooling is a hard fail (was previously fail-open with an
+    # "CI will catch it" hint, but that defeated the purpose of the
+    # local hook). Skip per-commit with --no-verify if you genuinely
+    # need to bypass it.
     conventional-commits:
       run: |
         if ! command -v bun >/dev/null 2>&1; then
-          echo "lefthook: bun not on PATH; skipping commit-msg lint (CI will catch any issues). Install bun: https://bun.sh" >&2
-          exit 0
+          echo "lefthook: bun not on PATH. Install bun (https://bun.sh) or skip with: git commit --no-verify" >&2
+          exit 1
         fi
         if [ ! -d node_modules ]; then
-          echo "lefthook: node_modules missing; run 'bun install' to enable the commit-msg lint locally (CI will catch any issues)." >&2
-          exit 0
+          echo "lefthook: node_modules missing. Run 'bun install' or skip with: git commit --no-verify" >&2
+          exit 1
         fi
         bun scripts/lint-commit.mjs --edit {1}
 
@@ -37,15 +39,17 @@ pre-commit:
       glob: "*.go"
       run: go vet ./...
     # Mirror what CI runs so a clean pre-commit means a clean CI run.
-    # Install once: go install honnef.co/go/tools/cmd/staticcheck@latest
-    # If staticcheck isn't on PATH, this hook prints a hint and skips
-    # rather than failing — CI will catch any issue regardless.
+    # Hard-fails if staticcheck isn't installed (was previously fail-open
+    # with a hint, but that meant first-time clones could land breaking
+    # changes that only failed on CI). Skip per-commit with --no-verify
+    # if you need to.
     staticcheck:
       glob: "*.go"
       run: |
         if ! command -v staticcheck >/dev/null 2>&1; then
-          echo "staticcheck not found on PATH; skipping (install: go install honnef.co/go/tools/cmd/staticcheck@latest)"
-          exit 0
+          echo "staticcheck not on PATH. Install with: go install honnef.co/go/tools/cmd/staticcheck@latest" >&2
+          echo "Or skip this commit with: git commit --no-verify" >&2
+          exit 1
         fi
         staticcheck ./...
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -52,6 +52,22 @@ pre-commit:
           exit 1
         fi
         staticcheck ./...
+    # Keep the README's auto-generated TOC in sync. Same pattern as the
+    # gofmt step: regenerate, re-stage, don't fail. doctoc is a no-op when
+    # the TOC is already current.
+    doctoc:
+      glob: "README.md"
+      run: |
+        if ! command -v bun >/dev/null 2>&1; then
+          echo "lefthook: bun not on PATH. Install bun (https://bun.sh) or skip with: git commit --no-verify" >&2
+          exit 1
+        fi
+        if [ ! -d node_modules ]; then
+          echo "lefthook: node_modules missing. Run 'bun install' or skip with: git commit --no-verify" >&2
+          exit 1
+        fi
+        bun run toc
+      stage_fixed: true
 
 pre-push:
   commands:

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "description": "Repo-level tooling that isn't tied to the docs site (which has its own package.json under docs/). Currently: a commit-message linter that uses the same parser release-please uses, so a commit that breaks release-please's parser fails CI before it can land on main.",
   "type": "module",
   "scripts": {
-    "lint-commits": "node scripts/lint-commit.mjs"
+    "lint-commits": "node scripts/lint-commit.mjs",
+    "toc": "doctoc README.md --github --title '## Table of contents'"
   },
   "devDependencies": {
-    "@conventional-commits/parser": "^0.4.1"
+    "@conventional-commits/parser": "^0.4.1",
+    "doctoc": "^2.2.1"
   }
 }

--- a/scripts/foreach-module.sh
+++ b/scripts/foreach-module.sh
@@ -11,6 +11,21 @@
 
 set -euo pipefail
 
+# Internal entrypoint: run `go test` for one module and print its output
+# atomically. Used by the parallelized `test` op so concurrent module
+# output doesn't interleave. Not part of the public op set.
+if [ "${1:-}" = "__test_one" ]; then
+  shift
+  mod="$1"
+  out=$(cd "$mod" && go test -race -count=1 ./... 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    printf '==> %s (test)\n%s\n' "$mod" "$out"
+  else
+    printf '==> %s (test) FAILED (rc=%d)\n%s\n' "$mod" "$rc" "$out" >&2
+  fi
+  exit "$rc"
+fi
+
 # All Go modules in the repo. Order is intentional: main first, then
 # sub-modules. Don't reorder without a reason.
 ALL_MODULES=(
@@ -143,37 +158,53 @@ case "$op" in
   test)
     # Example modules have no tests; skip to avoid the confusing
     # "[no test files]" output. Every other module has tests.
-    for mod in \
-      . \
-      transports/blank \
-      transports/central \
-      transports/charmlog \
-      transports/console \
-      transports/datadog \
-      transports/lumberjack \
-      transports/http \
-      transports/logrus \
-      transports/otellog \
-      transports/phuslu \
-      transports/pretty \
-      transports/sentry \
-      transports/slog \
-      transports/structured \
-      transports/testing \
-      transports/zap \
-      transports/zerolog \
-      plugins/datadogtrace \
-      plugins/datadogtrace/livetest \
-      plugins/fmtlog \
-      plugins/oteltrace \
-      plugins/plugintest \
-      plugins/redact \
-      plugins/sampling \
-      integrations/loghttp \
-      integrations/sloghandler; do
-      echo "==> $mod (test)"
-      (cd "$mod" && go test -race -count=1 ./...)
-    done
+    TEST_MODULES=(
+      .
+      transports/blank
+      transports/central
+      transports/charmlog
+      transports/console
+      transports/datadog
+      transports/lumberjack
+      transports/http
+      transports/logrus
+      transports/otellog
+      transports/phuslu
+      transports/pretty
+      transports/sentry
+      transports/slog
+      transports/structured
+      transports/testing
+      transports/zap
+      transports/zerolog
+      plugins/datadogtrace
+      plugins/datadogtrace/livetest
+      plugins/fmtlog
+      plugins/oteltrace
+      plugins/plugintest
+      plugins/redact
+      plugins/sampling
+      integrations/loghttp
+      integrations/sloghandler
+    )
+    # Run modules concurrently. Each `go test ./...` already parallelizes
+    # within a module; this layer parallelizes across modules so the
+    # 27-module sequence stops being a 27x process-startup tax. Output
+    # from each module is buffered by `__test_one` and printed atomically
+    # so the lines from different modules don't interleave.
+    #
+    # Override with PARALLEL=1 to force serial (helpful when debugging a
+    # specific module's output). getconf works on both Linux and macOS;
+    # falls back to 4 if neither is available.
+    PARALLEL="${PARALLEL:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
+    if [ "$PARALLEL" -le 1 ]; then
+      for mod in "${TEST_MODULES[@]}"; do
+        "$0" __test_one "$mod"
+      done
+    else
+      printf '%s\n' "${TEST_MODULES[@]}" |
+        xargs -n1 -P "$PARALLEL" -I{} "$0" __test_one {}
+    fi
     ;;
   build)
     for mod in "${ALL_MODULES[@]}"; do


### PR DESCRIPTION
## Summary

Two related cleanups on the local hooks + CI loop:

**Parallelize per-module tests.** `scripts/foreach-module.sh test` ran ~27 modules sequentially (~35s pre-push). Now dispatches each module's `go test -race` through `xargs -P $(nproc)` via an internal `__test_one` entrypoint that prints output atomically so concurrent modules don't interleave. Pre-push drops from ~35s to ~4s on an 8-core box. Override with `PARALLEL=1` for serial output when debugging a specific module. The "~15s" claim in `AGENTS.md` was already stale; updated.

**Fail closed on missing hook tooling.** The `commit-msg` and `pre-commit/staticcheck` hooks were previously fail-open with an "exit 0 + CI will catch it" hint. That defeats the point of the local hook (commits land that pass locally and fail on someone else's CI). Flipped to `exit 1` with a precise install hint and a `--no-verify` escape. The lefthook-itself-missing case is still fail-open because that's controlled by the git hook script lefthook generates, not by `lefthook.yml`; AGENTS.md notes this.

**CI tool caching, smaller wins:**
- `cache-dependency-path: '**/go.sum'` on `setup-go` so sub-module deps actually populate the cache (default only hashes the root go.sum).
- Pin `staticcheck` to `2026.1` and `govulncheck` to `v1.1.4` so a new release with new lints can't break CI out of nowhere.
- Cache the installed tool binaries in `~/go/bin` keyed on tool + Go version so the cache-hit path skips `go install`'s recompile.
- Cache `~/.cache/staticcheck` so unchanged packages aren't re-analyzed across runs.

Considered the maintainer-published `dominikh/staticcheck-action` and `golang/govulncheck-action` and rejected both: they assume single-module repos (always run the tool against one working-directory) and don't compose with the foreach-module loop. Direct `actions/cache` gets the same wins with no third-party action.

**Bookkeeping:** `bun install` (now mandatory because of the strict commit-msg hook) was leaving `node_modules/` and `bun.lock` untracked in the root. Added both to `.gitignore`; `docs/bun.lock` is the only committed lockfile and that's unchanged.

## Test plan

- [x] `scripts/foreach-module.sh test` runs clean and is ~10x faster than serial on this box.
- [x] `PARALLEL=1 scripts/foreach-module.sh test` still runs serial.
- [x] Failed-test exit code propagates through the parallel path (verified with a synthetic failing module).
- [x] `staticcheck@2026.1` runs clean on every shipped module.
- [x] `git commit` without `node_modules` fails with a clear hint (verified by accidentally tripping the new behavior).
- [ ] CI run on this PR confirms the cached tool paths exist and the cache keys behave on cold/warm runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)