### PR TITLE
chore: bump every module touched by #28 to refresh pkg.go.dev

### DIFF
--- a/plugins/datadogtrace/datadogtrace.go
+++ b/plugins/datadogtrace/datadogtrace.go
@@ -48,6 +48,8 @@
 //	handlerLog.Info("served")
 //	// Output includes dd.trace_id and dd.span_id, ready for log/trace
 //	// correlation in the Datadog UI.
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package datadogtrace
 
 import (

--- a/plugins/fmtlog/fmtlog.go
+++ b/plugins/fmtlog/fmtlog.go
@@ -14,6 +14,8 @@
 // message is a string and there are extra arguments is rewritten to
 // fmt.Sprintf(messages[0], messages[1:]...) before downstream
 // MessageHooks run.
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package fmtlog
 
 import (

--- a/plugins/oteltrace/oteltrace.go
+++ b/plugins/oteltrace/oteltrace.go
@@ -32,6 +32,8 @@
 //	handlerLog := log.WithContext(r.Context())
 //	handlerLog.Info("served")
 //	// {"level":"info","msg":"served","trace_id":"4bf...","span_id":"00f..."}
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package oteltrace
 
 import (

--- a/plugins/redact/redact.go
+++ b/plugins/redact/redact.go
@@ -21,6 +21,8 @@
 //	log.AddPlugin(redact.New(redact.Config{
 //	    Keys: []string{"password", "apiKey", "ssn"},
 //	}))
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package redact
 
 import (

--- a/plugins/sampling/sampling.go
+++ b/plugins/sampling/sampling.go
@@ -13,6 +13,8 @@
 //
 // Compose by registering multiple instances; each runs as its own SendGate
 // and an emission is kept only when every gate returns true.
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package sampling
 
 import (

--- a/transports/blank/blank.go
+++ b/transports/blank/blank.go
@@ -7,6 +7,8 @@
 // If you find yourself reusing the same blank.Config in multiple places,
 // promote it to its own transport package; see
 // /transports/creating-transports.md for the full template.
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package blank
 
 import (

--- a/transports/charmlog/charmlog.go
+++ b/transports/charmlog/charmlog.go
@@ -1,4 +1,6 @@
 // Package charmlog provides a LogLayer transport backed by github.com/charmbracelet/log.
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package charmlog
 
 import (

--- a/transports/console/console.go
+++ b/transports/console/console.go
@@ -1,5 +1,7 @@
 // Package console provides a Transport that writes log entries to stdout/stderr
 // using logfmt-style output (key=value pairs after the message).
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package console
 
 import (

--- a/transports/datadog/datadog.go
+++ b/transports/datadog/datadog.go
@@ -8,6 +8,8 @@
 //     and metadata
 //
 // API reference: https://docs.datadoghq.com/api/latest/logs/#send-logs
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package datadog
 
 import (

--- a/transports/http/http.go
+++ b/transports/http/http.go
@@ -6,6 +6,8 @@
 // Mental model: log calls enqueue entries into a buffered channel; a
 // background worker drains the channel into batches and POSTs them. Use Close
 // to drain pending entries on shutdown.
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package httptransport
 
 import (

--- a/transports/logrus/logrus.go
+++ b/transports/logrus/logrus.go
@@ -1,4 +1,6 @@
 // Package logrus provides a LogLayer transport backed by github.com/sirupsen/logrus.
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package logrus
 
 import (

--- a/transports/lumberjack/lumberjack.go
+++ b/transports/lumberjack/lumberjack.go
@@ -11,6 +11,8 @@
 // The package name shadows the upstream `gopkg.in/natefinch/lumberjack.v2`
 // (which is also `package lumberjack`); within this file the upstream is
 // aliased to lj. Callers that import both can use a similar alias.
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package lumberjack
 
 import (

--- a/transports/otellog/otellog.go
+++ b/transports/otellog/otellog.go
@@ -34,6 +34,8 @@
 //	    Version:        "1.2.3",
 //	    LoggerProvider: provider,
 //	})
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package otellog
 
 import (

--- a/transports/phuslu/phuslu.go
+++ b/transports/phuslu/phuslu.go
@@ -1,4 +1,6 @@
 // Package phuslu provides a LogLayer transport backed by github.com/phuslu/log.
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package phuslu
 
 import (

--- a/transports/pretty/pretty.go
+++ b/transports/pretty/pretty.go
@@ -1,6 +1,8 @@
 // Package pretty provides a colorized terminal transport that renders log
 // entries with theme-aware formatting and three view modes (inline,
 // message-only, expanded). Inspired by loglayer's simple-pretty-terminal.
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package pretty
 
 import (

--- a/transports/sentry/sentry.go
+++ b/transports/sentry/sentry.go
@@ -11,6 +11,8 @@
 // than [sentry.Logger.Fatal], so loglayer's core decides whether to
 // call os.Exit (per Config.DisableFatalExit). The Panic level maps to
 // LFatal as well; loglayer's core does the panic separately.
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package sentrytransport
 
 import (

--- a/transports/slog/slog.go
+++ b/transports/slog/slog.go
@@ -4,6 +4,8 @@
 // Use this transport when your codebase or its dependencies are wired against
 // *slog.Logger and you want LogLayer's API on top, or when you want to plug
 // LogLayer into a slog-based handler stack (JSON, text, OpenTelemetry, etc).
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package slog
 
 import (

--- a/transports/structured/structured.go
+++ b/transports/structured/structured.go
@@ -1,5 +1,7 @@
 // Package structured provides a Transport that always outputs a single
 // JSON object per log entry with msg, level, and time fields by default.
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package structured
 
 import (

--- a/transports/testing/testing.go
+++ b/transports/testing/testing.go
@@ -1,5 +1,7 @@
 // Package testing provides a TestTransport and TestLoggingLibrary for use in tests.
 // Import this package only in test files.
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package testing
 
 import (

--- a/transports/zap/zap.go
+++ b/transports/zap/zap.go
@@ -1,4 +1,6 @@
 // Package zap provides a LogLayer transport backed by go.uber.org/zap.
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package zap
 
 import (

--- a/transports/zerolog/zerolog.go
+++ b/transports/zerolog/zerolog.go
@@ -5,6 +5,8 @@
 // Config.DisableFatalExit). This transport never invokes the underlying
 // library's exit path, regardless of how the wrapped *zerolog.Logger is
 // configured.
+//
+// See https://go.loglayer.dev for usage guides and the full API reference.
 package zerolog
 
 import (


### PR DESCRIPTION
## Summary

Force release-please to cut a patch release across every module that received new godoc surface in #28, so pkg.go.dev's default landing for each one renders the new \`Example*\` functions and (for the main module) the new \`doc.go\` overview.

#28 used the \`docs:\` type, which is hidden in \`release-please-config.json\`'s \`changelog-sections\` and therefore doesn't trigger a release. Without intervention, every package's pkg.go.dev page stays on its prior tag indefinitely.

## What this PR does

22 commits, each path-scoped to one component, each carrying a \`Release-As:\` footer that release-please honors:

- **21 sub-modules**: each commit adds one line to the package's main \`.go\` file extending the \`// Package\` overview comment with \`See https://go.loglayer.dev for usage guides and the full API reference.\` This is a small but real reader-facing improvement and provides the path scope release-please needs to attach the \`Release-As:\` to that specific package.
- **1 root commit**: empty, \`Release-As: 1.6.1\`.

\`transports/central\` is excluded — it isn't yet registered in \`release-please-config.json\`.
\`integrations/loghttp\`, \`integrations/sloghandler\`, \`plugins/plugintest\` are excluded — they didn't receive Examples in #28 so there's nothing new to expose.

## Versions

| Component | From | To |
|-----------|------|-----|
| \`go.loglayer.dev\` | 1.6.0 | 1.6.1 |
| \`transports/blank\` | 1.1.0 | 1.1.1 |
| \`transports/charmlog\` | 1.3.0 | 1.3.1 |
| \`transports/console\` | 1.1.0 | 1.1.1 |
| \`transports/datadog\` | 1.3.0 | 1.3.1 |
| \`transports/http\` | 1.3.0 | 1.3.1 |
| \`transports/logrus\` | 1.3.0 | 1.3.1 |
| \`transports/lumberjack\` | 1.1.0 | 1.1.1 |
| \`transports/otellog\` | 1.3.0 | 1.3.1 |
| \`transports/phuslu\` | 1.3.0 | 1.3.1 |
| \`transports/pretty\` | 1.2.0 | 1.2.1 |
| \`transports/sentry\` | 1.1.0 | 1.1.1 |
| \`transports/slog\` | 1.3.0 | 1.3.1 |
| \`transports/structured\` | 1.1.0 | 1.1.1 |
| \`transports/testing\` | 1.0.0 | 1.0.1 |
| \`transports/zap\` | 1.3.0 | 1.3.1 |
| \`transports/zerolog\` | 1.3.0 | 1.3.1 |
| \`plugins/datadogtrace\` | 1.1.1 | 1.1.2 |
| \`plugins/fmtlog\` | 1.1.1 | 1.1.2 |
| \`plugins/oteltrace\` | 1.1.1 | 1.1.2 |
| \`plugins/redact\` | 1.1.1 | 1.1.2 |
| \`plugins/sampling\` | 1.1.1 | 1.1.2 |

Supersedes #29 (which only bumped the root module).

## Test plan

- [x] \`go test -race -count=1 ./...\` across every module via \`scripts/foreach-module.sh test\` (passed in pre-push hook)
- [x] \`go vet ./...\` and \`staticcheck ./...\` clean
- [x] \`go mod tidy\` clean across all modules (verified by pre-push tidy step)
- [x] Each commit's conventional-commits format validated by lefthook commit-msg hook
- [ ] After merge: confirm release-please opens release PRs proposing the versions above
- [ ] After release-PR merges: confirm the corresponding tags exist
- [ ] After ~10 minutes: spot-check 2-3 sub-module pkg.go.dev pages render their new \`ExampleNew\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)