### PR TITLE
docs: use structured transport in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,18 @@ Requires **Go 1.25+** for the main module.
 For full documentation, read the [docs](https://go.loglayer.dev).
 
 ```go
-// Example using the Pretty terminal transport.
+// Example using the Structured (JSON) transport.
 // You can start out with one transport and swap to another later
 // without touching application code.
 import (
     "errors"
 
     "go.loglayer.dev"
-    "go.loglayer.dev/transports/pretty"
+    "go.loglayer.dev/transports/structured"
 )
 
 log := loglayer.New(loglayer.Config{
-    Transport: pretty.New(pretty.Config{}),
+    Transport: structured.New(structured.Config{}),
     // Put fields under "context" and metadata under "metadata"
     // (defaults are flattened to the root).
     FieldsKey:         "context",


### PR DESCRIPTION
## Summary

The README's quickstart imported \`transports/pretty\` but showed JSON output. \`pretty\` produces colorized terminal text, not JSON, so the rendered code and the rendered output block didn't match. Swap to \`transports/structured\`, which is what actually emits the shown JSON.

Only the import path, comment, and constructor change. The Config (FieldsKey/MetadataFieldName) and the rendered JSON block are unchanged — they were already correct for the structured transport's behavior.

## Test plan

- [x] Diff inspection: import + constructor swap, no other prose change
- [x] Conventional-commits validation passed (lefthook commit-msg hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)