### PR TITLE
chore(release-please): scope root component, force gcplogging v1.0.0

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -24,7 +24,18 @@
       "release-type": "go",
       "package-name": "go.loglayer.dev",
       "include-component-in-tag": false,
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "exclude-paths": [
+        ".claude",
+        ".github",
+        ".release-please-config.json",
+        ".release-please-manifest.json",
+        "docs",
+        "go.work",
+        "Makefile",
+        "lefthook.yml",
+        "scripts"
+      ]
     },
     "transports/charmlog": {
       "release-type": "go",

--- a/transports/gcplogging/CHANGELOG.md
+++ b/transports/gcplogging/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
-All notable changes to this package will be documented in this file. See
-[Conventional Commits](https://www.conventionalcommits.org/) for commit
-guidelines.
+All notable changes to `go.loglayer.dev/transports/gcplogging` are
+documented in this file. Format follows
+[Keep a Changelog](https://keepachangelog.com); versioning follows
+[SemVer](https://semver.org/). Conventional commits drive releases via
+[Release Please](https://github.com/googleapis/release-please).


### PR DESCRIPTION
## Summary

Two structural fixes for the monorepo-scoping issues that surfaced when release-please opened [PR #34](https://github.com/loglayer/loglayer-go/pull/34) after [#33](https://github.com/loglayer/loglayer-go/pull/33) merged.

### Problem 1: main was bumped to v1.7.0

Release-please attributes commits to packages by **file path**, not by the conventional-commit scope in the title. The squash-merge of #33 was titled \`feat(transports/gcplogging): initial release\` but its diff touched root-level files (\`docs/\`, \`scripts/\`, \`go.work\`, \`.release-please-config.json\`, \`.release-please-manifest.json\`) in addition to \`transports/gcplogging/\`. Without \`exclude-paths\` configured, every sub-module addition cascades into a root release. That contradicts the documented \"main stays on v1 forever, sub-modules absorb breakage independently\" design (set up by \`bbcd772\`).

**Fix:** add \`exclude-paths\` to the root \`.\` package config covering the typical sub-module-addition wiring: \`docs\`, \`scripts\`, \`.github\`, \`.claude\`, \`go.work\`, \`Makefile\`, \`lefthook.yml\`, and the release-please config / manifest themselves. Sub-modules' files are unaffected — they're claimed by their own package \`path\`.

### Problem 2: transports/gcplogging was proposed at v1.1.0 instead of v1.0.0

The gcplogging manifest entry was \`0.0.0\` (never released), so release-please scanned the entire commit range from repo origin for relevant \`Release-As:\` footers. It found \`bbcd772\`'s \`Release-As: 1.1.0\` (intended for the root component after an older fmtlog breaking migration) and applied it to gcplogging, since release-please uses path attribution and \`bbcd772\` was at the root with no \`exclude-paths\` in effect at that time. The squash-merge of #33 silently stripped my pre-merge \`Release-As: 1.0.0\` footer (GitHub squash-merge uses the PR title and body, not the local commit messages), so nothing currently overrides the leak.

**Fix:** land a new gcplogging-path-scoped commit with \`Release-As: 1.0.0\` in its footer to override \`bbcd772\` for this package specifically. The CHANGELOG.md tweak gives the commit a real diff under \`transports/gcplogging/\` so it's path-attributed correctly.

### How this commit attributes

The diff has two files:

- \`.release-please-config.json\` — excluded from root attribution by the same \`exclude-paths\` it adds (release-please reads the config at HEAD when evaluating).
- \`transports/gcplogging/CHANGELOG.md\` — under gcplogging's path, so attributed to gcplogging.

So the commit attributes only to gcplogging, and \`Release-As: 1.0.0\` applies cleanly there.

### What happens after merge

Release-please re-evaluates with the new config and refreshes [PR #34](https://github.com/loglayer/loglayer-go/pull/34) (or closes + re-opens). Expected new state: no main bump (root has no attributable commits), \`transports/gcplogging\` proposed at \`v1.0.0\`.

## Test plan

- [x] Conventional-commits format validates (lefthook commit-msg hook passed)
- [x] \`Release-As: 1.0.0\` footer is in the commit body so squash-merge preserves it (also in this PR body, see below)
- [ ] After merge: confirm release-please refreshes PR #34 — main bump dropped, gcplogging at \`v1.0.0\`

\`Release-As: 1.0.0\` for \`transports/gcplogging\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)