### PR TITLE
chore(release-please): sync manifest to manual transports/gcplogging v1.0.0 tag

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,7 +2,7 @@
   ".": "1.6.1",
   "transports/charmlog": "1.6.1",
   "transports/datadog": "1.6.1",
-  "transports/gcplogging": "0.0.0",
+  "transports/gcplogging": "1.0.0",
   "transports/lumberjack": "1.6.1",
   "transports/http": "1.6.1",
   "transports/logrus": "1.6.1",


### PR DESCRIPTION
## Summary

Syncs \`.release-please-manifest.json\` to reflect the manually-created \`transports/gcplogging/v1.0.0\` tag, after [PR #34](https://github.com/loglayer/loglayer-go/pull/34) was closed (it mis-proposed main as v1.0.0).

## Background

PR #34's main \`v1.0.0\` proposal would have downgraded main from \`v1.6.1\`. Cause: a simple \`Release-As: 1.0.0\` footer in #35's body was applied project-wide by release-please, forcing both packages to the same version. release-please does not currently support per-component \`Release-As\` footer syntax to scope an override to one package.

## What was done

1. Closed PR #34 to cancel the bad proposal.
2. Manually created the [\`transports/gcplogging/v1.0.0\`](https://github.com/loglayer/loglayer-go/releases/tag/transports/gcplogging/v1.0.0) tag and GitHub Release pointing at \`b5c9ef5\` (current main, includes #33 + #35).
3. **This PR** updates the manifest (\`transports/gcplogging\`: \`0.0.0\` → \`1.0.0\`) so release-please's next scan sees the package as released and doesn't try to re-release.

After this merges, release-please tracks \`transports/gcplogging\` from \`v1.0.0\` via the standard conventional-commits flow. The structural \`exclude-paths\` config from #35 is still in place to prevent future sub-module additions from cascading into root releases.

## Diff scope

Only \`.release-please-manifest.json\`, which is in root's \`exclude-paths\` (per #35), so this commit doesn't attribute to the root component and won't trigger a main release.

## Test plan

- [x] Tag exists: https://github.com/loglayer/loglayer-go/releases/tag/transports/gcplogging/v1.0.0
- [x] Manifest entry matches the tag (\`1.0.0\`)
- [ ] After merge: confirm release-please does not open a new release PR proposing anything for \`transports/gcplogging\` or main
- [ ] After ~10 minutes: confirm pkg.go.dev renders \`go.loglayer.dev/transports/gcplogging@v1.0.0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)