### PR TITLE
chore(release-please): bootstrap-sha root past leaked footer

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -25,6 +25,7 @@
       "package-name": "go.loglayer.dev",
       "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
+      "bootstrap-sha": "df9073d15860114115efe3ab57bfd4915b84e43a",
       "exclude-paths": [
         ".claude",
         ".github",


### PR DESCRIPTION
## Summary

Resolves [PR #37](https://github.com/loglayer/loglayer-go/pull/37) (and the recurring \"main wants to release at v1.0.0\" loop) by setting \`bootstrap-sha\` on the root package config to \`df9073d\` (current main HEAD).

## Why

[PR #37](https://github.com/loglayer/loglayer-go/pull/37) is release-please's auto-generated release PR proposing main at \`v1.0.0\`. The trigger is a leaked \`Release-As: 1.0.0\` footer in \`b5c9ef5\` (the squash-merge body of [#35](https://github.com/loglayer/loglayer-go/pull/35)). release-please applies simple \`Release-As:\` footers project-wide; the [\`exclude-paths\` config](https://github.com/loglayer/loglayer-go/blob/main/.release-please-config.json) only filters file-based attribution, not footer-based release triggers. Closing PR #37 manually doesn't stick — release-please re-evaluates on every push to main and reopens the same proposal because \`b5c9ef5\` is still in main's unreleased eval range.

## What this does

\`bootstrap-sha\` tells release-please to ignore commits **at or before** the given SHA when computing a package's release. Setting it on the root config to \`df9073d\` (the merge of [#38](https://github.com/loglayer/loglayer-go/pull/38), current main HEAD) puts the leaked \`b5c9ef5\` footer below main's eval boundary. release-please now sees \"nothing to release for root\" because the eval range is empty (no commits after \`df9073d\` yet).

Sub-modules are unaffected — their per-package manifest entries already gate them past their last release independently.

## Why not the alternatives

- **Option A: \`release-as: \"1.7.0\"\` for root** — works, but creates a v1.7.0 main tag for a release that has no actual main-module changes. Violates the documented \"main stays on v1 forever\" property.
- **Option B: manual close-and-bypass dance** — close PR #37 by hand. release-please re-opens it on the next push to main. Not sustainable.

\`bootstrap-sha\` is the surgical fix: skip the leak without bumping main.

## Risk

\`bootstrap-sha\` is documented primarily for *initial* setup of release-please on an existing repo (telling it where to start scanning from). Mid-life adjustment isn't an explicitly-supported use case. If release-please ignores it for already-configured packages, this PR is a no-op and we'd fall back to option A in a follow-up.

## Test plan

- [x] Validator (\`scripts/check-release-please-state.sh\`) clean against the new config
- [ ] After merge: confirm release-please refreshes [PR #37](https://github.com/loglayer/loglayer-go/pull/37) — proposal for main should disappear
- [ ] If PR #37 still shows main at v1.0.0 after release-please runs: revert and use option A instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)