### PR TITLE
chore(release-please): remove stale release-as on root after v1.6.2

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -25,7 +25,6 @@
       "package-name": "go.loglayer.dev",
       "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
-      "release-as": "1.6.2",
       "exclude-paths": [
         ".claude",
         ".github",


### PR DESCRIPTION
## Summary

Removes \`\"release-as\": \"1.6.2\"\` from the root package config. The override has been applied (\`v1.6.2\` is tagged, manifest is at \`1.6.2\`), so leaving it in place would pin every future root release to \`1.6.2\` and the validator (\`scripts/check-release-please-state.sh\`) flags it as stale.

## Sequence of what happened

1. **#41** added \`release-as: \"1.6.2\"\` to escape the \`b5c9ef5\` \`Release-As: 1.0.0\` leak.
2. **#42** (release-please's auto release-PR) merged, advancing the root manifest from \`1.6.1\` → \`1.6.2\` and updating \`CHANGELOG.md\`.
3. The release-please workflow on the post-merge push **aborted with \"untagged, merged release PRs outstanding\"** before creating the \`v1.6.2\` tag.
4. Manual fix via \`gh release create v1.6.2 --target 9e03516 --title v1.6.2 ...\` to bring reality (tag exists) in line with the manifest (claims \`1.6.2\` released).
5. **This PR** removes the now-stale \`release-as\` so future root releases use conventional commits.

After this merges, root is back to "release on actual main code changes only" — `exclude-paths` keeps `docs/`, `scripts/`, etc. from triggering, and there's no `release-as` pinning the version.

## Why release-please aborted

Best guess: release-please's tag-creation step has a safety check that aborts when it can't reconcile a merged release PR with the expected tag state. Likely a transient confusion from the multiple manual interventions earlier (#36 manual gcplogging tag, #34 closed). Going forward, with no manual interventions expected, release-please should resume normal tag-creation. If it aborts again on the next release, that's a deeper config issue worth investigating.

## Test plan

- [x] Validator (\`scripts/check-release-please-state.sh\`) clean after removing \`release-as\`
- [x] Conventional-commits format passes (lefthook commit-msg)
- [ ] After merge: confirm release-please does not propose a new root release (manifest matches reality, no new attributable commits)
- [ ] Next release of any sub-module: confirm release-please's tag-creation step works normally (not the \"aborting\" path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)