### PR TITLE
chore(transports/blank): smoke-test the monorel release pipeline

### DIFF
--- a/.changeset/monorel-smoke-test.md
+++ b/.changeset/monorel-smoke-test.md
@@ -1,0 +1,12 @@
+---
+"transports/blank": patch
+---
+
+Smoke test of the monorel migration. No functional change; this changeset
+exists only to exercise the full release pipeline (release-pr orchestrator →
+release.yml → tag push → publish → deploy-docs workflow_call) end-to-end
+on `transports/blank`, the lowest-blast-radius package in the repo.
+
+After this lands, `transports/blank/v1.6.2` is the first monorel-driven tag
+in this repo. Future releases follow the same path; this one verifies the
+chain works.


### PR DESCRIPTION
## Summary

First post-migration release exercise. Adds a `:patch` changeset on `transports/blank` so the full monorel pipeline (release-pr orchestrator → release.yml → tag push → publish → deploy-docs `workflow_call` chain) runs end-to-end against this repo for the first time.

`transports/blank` is the deliberately low-blast-radius target: the no-op template transport. A `v1.6.1 → v1.6.2` patch bump on it has no functional impact on any downstream consumer.

## What this verifies

- [x] `release-pr` workflow renders the changeset into the always-open release PR's body.
- [ ] Release PR shows the plan (`transports/blank: 1.6.1 → 1.6.2`).
- [ ] Merging the release PR runs `release.yml` → creates tag `transports/blank/v1.6.2` on origin.
- [ ] `monorel publish` creates the GitHub Release with the rendered changelog body.
- [ ] `deploy-docs` `workflow_call` chain runs (validates the audit-table claim that monorel's `GITHUB_TOKEN`-created Releases need the same anti-recursion workaround release-please used).

The last item is the audit-table line item the spec flagged: monorel itself doesn't exercise this pattern in its own repo, so loglayer-go is the first verifier.

## After this lands

The migration spec's `monorel/docs/src/recipes/loglayer-go.md` "Pending" placeholder gets updated with the real outcome (smoke-test PR link + verification results) on the monorel side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)