### PR TITLE
chore(ci): bump disaresta-org/monorel/ci/github to v0.1.2

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -33,6 +33,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: disaresta-org/monorel/ci/github@v0.1.0
+      - uses: disaresta-org/monorel/ci/github@v0.1.2
         with:
           command: pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: disaresta-org/monorel/ci/github@v0.1.0
+      - uses: disaresta-org/monorel/ci/github@v0.1.2
         with:
           command: release
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ go.work.sum
 *.sublime-workspace
 .DS_Store
 Thumbs.db
+
+# Claude Code runtime state
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary

Bumps the action wrapper pin in `release-pr.yml` and `release.yml` from `@v0.1.0` to `@v0.1.2`. Skips `v0.1.1` because that release went out without binary assets attached (CI bug fixed in v0.1.2).

## Why

`v0.1.0`'s wrapper didn't stage the `monorel/release` head branch before invoking `monorel preview --upsert`, so GitHub's PR-create API rejected the always-open release PR with `422 Field:head Code:invalid`. That's exactly what blocked the `transports/blank` smoke-test PR from opening its release PR. `v0.1.2` ships the branch-staging fix.

## After merge

Re-trigger `release-pr.yml` on the smoke-test merge commit (push an empty commit on main, or use `gh workflow run`) — the always-open release PR for `transports/blank: 1.6.1 → 1.6.2` should open cleanly. Merging that PR cuts loglayer-go's first monorel-driven release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)