### PR TITLE
fix: shorten v2 changeset body so the release PR fits GitHub's 64KiB limit

### DIFF
--- a/.changeset/v2-prefix-passthrough.md
+++ b/.changeset/v2-prefix-passthrough.md
@@ -28,49 +28,6 @@
 "integrations/sloghandler": major
 ---
 
-**Breaking: import paths bump to `/v2`.**
+**Breaking: import paths bump to `/v2`.** The loglayer core no longer folds the `WithPrefix` value into `Messages[0]`; the prefix flows through `TransportParams.Prefix` and each transport renders it. Built-in transports preserve their prior user-visible output via the new `transport.JoinPrefixAndMessages` helper. The `cli` transport opts into smart rendering (dim-grey user prefix separate from level color).
 
-The loglayer core no longer mutates `Messages[0]` to fold the `WithPrefix` value into the message text. The prefix flows through `TransportParams.Prefix` (and the matching field on every dispatch-time plugin hook param struct). Each transport decides how to render the prefix:
-
-- Most built-in transports call `transport.JoinPrefixAndMessages(params.Prefix, params.Messages)` at the top of `SendToLogger` to preserve the v1 user-visible output exactly.
-- The cli transport opts into smart rendering: the level prefix and message body keep the level color (yellow / red), while the `WithPrefix` value gets its own dim-grey color, visually separating caller-context from urgency.
-- The `blank` transport intentionally passes raw v2 params through to the user-supplied `ShipToLogger` function, so advanced users can decide their own rendering.
-
-## Migration
-
-Every consumer must update import paths to `/v2`:
-
-```sh
-go get go.loglayer.dev/v2 \
-       go.loglayer.dev/transports/cli/v2 \
-       go.loglayer.dev/transports/zerolog/v2 \
-       # ... whichever sub-modules you import
-```
-
-In source files:
-
-```diff
--import (
--    "go.loglayer.dev"
--    "go.loglayer.dev/transports/zerolog"
--)
-+import (
-+    "go.loglayer.dev/v2"
-+    "go.loglayer.dev/transports/zerolog/v2"
-+)
-```
-
-For most users no other changes are needed: the built-in transports preserve v1 user-visible output. Custom transports that consumed `params.Messages[0]` and assumed the prefix was already prepended must either:
-
-1. Call `transport.JoinPrefixAndMessages(params.Prefix, params.Messages)` at the top of `SendToLogger` (legacy behavior preserved), or
-2. Read `params.Prefix` directly and render it however you like (e.g. as a separate JSON field, in its own color, forwarded to the underlying logger's structured-field API).
-
-The new `transport.JoinPrefixAndMessages` helper has fast-path early returns when the prefix is empty, when messages is empty, or when `messages[0]` isn't a string; the per-call cost for any logger that hasn't called `WithPrefix` is one string compare.
-
-## Plugin authors
-
-Plugin hooks (`OnBeforeDataOut`, `OnBeforeMessageOut`, `TransformLogLevel`, `ShouldSend`) gained a `Prefix string` field on their respective params structs (was added additively in v1.7.0). The field is read-only from the plugin's perspective. With v2, `params.Messages[0]` no longer carries the prefix; plugins that read messages directly should be aware that the prefix is now ONLY on `params.Prefix`.
-
-## See also
-
-The prior v1.7.0 release added `Prefix` to the param structs as an additive field; this release removes the auto-prepend.
+See [Migrating to v2](https://go.loglayer.dev/migrating-to-v2) for the upgrade checklist.


### PR DESCRIPTION
## Summary

The release-pr workflow failed on the v2 cascade merge ([run 25263868102](https://github.com/loglayer/loglayer-go/actions/runs/25263868102)) with:

\`\`\`
orchestrator: create PR: github: create PR monorel/release -> main:
POST .../pulls: 422 Validation Failed
[{Resource:Issue Field:body Code:custom Message:body is too long (maximum is 65536 characters)}]
\`\`\`

GitHub caps PR bodies at 65,536 characters. monorel renders the changeset body once per package in the release PR body; the prior \`v2-prefix-passthrough.md\` body was ~3,400 chars, so 27 packages × 3.4 KB + table overhead exceeded the limit.

## Fix

Trim the changeset body to ~700 chars. The full migration content lives at [\`docs/src/migrating-to-v2.md\`](https://go.loglayer.dev/migrating-to-v2), which the new body links to. Estimated rendered release-pr body after this PR merges: ~15.6 KB, comfortable under the limit.

## Follow-up

Worth a monorel issue: the always-open release PR body should auto-truncate (or summarize) when its rendered length would exceed the provider's limit, with a fallback link to the underlying changesets. Today the workflow fails closed.

## Test plan

- [x] \`wc -c .changeset/v2-prefix-passthrough.md\` reports 1253 (down from 3405).
- [ ] After merge, the next release-pr workflow run succeeds and opens the always-open release PR with the v2 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)