### PR TITLE
chore: republish v2 modules with clean go.mod

### DIFF
--- a/.changeset/republish-clean-gomod.md
+++ b/.changeset/republish-clean-gomod.md
@@ -1,0 +1,37 @@
+---
+"go.loglayer.dev": patch
+"integrations/loghttp": patch
+"integrations/sloghandler": patch
+"plugins/datadogtrace": patch
+"plugins/fmtlog": patch
+"plugins/oteltrace": patch
+"plugins/plugintest": patch
+"plugins/redact": patch
+"plugins/sampling": patch
+"transports/blank": patch
+"transports/charmlog": patch
+"transports/cli": patch
+"transports/console": patch
+"transports/datadog": patch
+"transports/gcplogging": patch
+"transports/http": patch
+"transports/logrus": patch
+"transports/lumberjack": patch
+"transports/otellog": patch
+"transports/phuslu": patch
+"transports/pretty": patch
+"transports/sentry": patch
+"transports/slog": patch
+"transports/structured": patch
+"transports/testing": patch
+"transports/zap": patch
+"transports/zerolog": patch
+---
+
+Republish every module to ship a clean `go.mod` to the Go module proxy.
+
+The v2.0.0 cascade and the subsequent `transports/cli` v2.1.0 release shipped sub-module `go.mod` files containing dev-only `replace go.loglayer.dev/v2 => ../..` directives and placeholder pseudo-version requires (`v2.0.0-00010101000000-000000000000`). Downstream consumers who depended on any sub-module saw `go mod tidy` 404 on the placeholder.
+
+monorel v0.9.0 ([disaresta-org/monorel#42](https://github.com/disaresta-org/monorel/pull/42)) added a release-time `go.mod` cleaner that strips the dev-only sibling replaces and pins sibling requires to the planned release version. This release republishes every affected module with the cleaned `go.mod`.
+
+No API changes. Re-`go get` to pick up the cleaned modules.

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -33,6 +33,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: disaresta-org/monorel/ci/github@v0.4.0
+      - uses: disaresta-org/monorel/ci/github@v0.9.0
         with:
           command: pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: disaresta-org/monorel/ci/github@v0.4.0
+      - uses: disaresta-org/monorel/ci/github@v0.9.0
         with:
           command: release
 


### PR DESCRIPTION
## Summary

- Pin the monorel CI action (`disaresta-org/monorel/ci/github`) from `v0.4.0` → `v0.9.0` in both `release-pr.yml` and `release.yml`. v0.9.0 ships the release-time `go.mod` cleaner from [disaresta-org/monorel#42](https://github.com/disaresta-org/monorel/pull/42).
- Add `.changeset/republish-clean-gomod.md` bumping every released module by `:patch`. Includes `go.loglayer.dev` (the root) so its currently-published `v2.0.0` ends up in the release plan and sub-modules' `go.loglayer.dev/v2` requires get pinned by the rewriter.

## Why

The v2.0.0 cascade (#63) and the subsequent `transports/cli` v2.1.0 release (#69) shipped sub-module `go.mod` files containing dev-only `replace go.loglayer.dev/v2 => ../..` directives and placeholder pseudo-version requires (`v2.0.0-00010101000000-000000000000`). Downstream consumers depending on any sub-module saw `go mod tidy` 404 on the placeholder.

monorel's `apply` step now strips dev-only sibling replaces and pins sibling requires to the planned release version, so the next merge of the always-open release PR will publish cleaned `go.mod` files for every module.

## What ships

- `go.loglayer.dev` `v2.0.0 → v2.0.1`
- 25 sub-modules `v2.0.0 → v2.0.1` (every package except `transports/cli`)
- `transports/cli` `v2.1.0 → v2.1.1`

No API changes. Consumers re-`go get` to pick up the cleaned modules.

## Test plan

- [ ] CI checks pass on this PR (build + tests + vet + staticcheck across every module).
- [ ] `release-pr` workflow runs after merge and updates the always-open release PR.
- [ ] Inspect the release PR's diff: each sub-module's `go.mod` should have its sibling `replace` line dropped and its `go.loglayer.dev/v2` require pinned to `v2.0.1` (or to the latest sibling version where applicable).
- [ ] Merge the release PR; verify `go install go.loglayer.dev/transports/zerolog/v2@v2.0.1` (or any other sub-module) tidies cleanly from a fresh module without `replace` workarounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)