### PR TITLE
fix(ci): install Go 1.25 before monorel for release-pr / release

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The monorel CI action runs `go mod tidy` per sub-module to refresh
+      # go.sum entries. Sub-modules require Go 1.25; the runner default is
+      # older and the action sets GOTOOLCHAIN=local, so install the Go we
+      # need explicitly before invoking monorel.
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
       - uses: disaresta-org/monorel/ci/github@v0.11.0
         with:
           command: pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The monorel CI action runs `go mod tidy` per sub-module to refresh
+      # go.sum entries. Sub-modules require Go 1.25; the runner default is
+      # older and the action sets GOTOOLCHAIN=local, so install the Go we
+      # need explicitly before invoking monorel.
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
       - uses: disaresta-org/monorel/ci/github@v0.11.0
         with:
           command: release


### PR DESCRIPTION
## Summary

The `release-pr` workflow fails on push-to-`main` after a sub-module touched by a changeset requires Go 1.25 (every sub-module does). Run [25272224403](https://github.com/loglayer/loglayer-go/actions/runs/25272224403/job/74096416562) is the surfaced incident.

```
tidy in /home/runner/work/loglayer-go/loglayer-go/transports/cli: exit status 1
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

## Root cause

`monorel` v0.12+ runs `go mod tidy` per sub-module as part of `pr` and `release` to refresh go.sum entries. The GitHub runner default Go is older than 1.25 and the monorel CI action sets `GOTOOLCHAIN=local`, so the toolchain doesn't auto-upgrade. Tidy then fails on every sub-module.

The action version is pinned (`disaresta-org/monorel/ci/github@v0.11.0`), but the action invokes the monorel binary under `latest`. Between PR #74's release-pr run (which resolved `latest` to ≤v0.11.0) and PR #76's run, monorel published v0.12.0 and v0.13.0. PR #76's run picked up v0.13.0, which surfaces the toolchain mismatch.

## Fix

Add `actions/setup-go@v5` with `go-version: '1.25'` before the monorel invocation in both `release-pr.yml` and `release.yml`. Mirrors the setup-go pattern that `ci.yml` already uses for the regular CI matrix.

This is robust against future monorel version bumps that need newer toolchains, since the runner now always has 1.25 (and Go's default `GOTOOLCHAIN=auto` would auto-upgrade past 1.25 if a sub-module ever requires it; the monorel action's `GOTOOLCHAIN=local` only blocks the auto-download, not a pre-installed newer version).

## Test plan

- [ ] After merge, the next push-to-main triggers `release-pr` and the workflow completes successfully (release PR opens / updates).
- [ ] At the next release-pr merge, the `release` workflow runs the publish pipeline cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)