### PR TITLE
fix(ci): skip CI on chore(release): commits to avoid tag-push race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The chore(release): merge commit updates each released module's
+  # go.mod to require a new go.loglayer.dev version. The matching tag
+  # is created concurrently by release.yml on the same push. Tidy here
+  # races with that tag push and loses; skip the run so the release
+  # workflow has the field to itself. The next non-release push to main
+  # triggers a clean CI.
   test:
+    if: github.event_name == 'pull_request' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: Test (Go ${{ matrix.go }})
     runs-on: ubuntu-latest
     strategy:
@@ -79,6 +86,7 @@ jobs:
         run: go build -o /dev/null ./...
 
   staticcheck:
+    if: github.event_name == 'pull_request' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: Staticcheck
     runs-on: ubuntu-latest
     env:
@@ -119,6 +127,7 @@ jobs:
         run: scripts/foreach-module.sh staticcheck
 
   govulncheck:
+    if: github.event_name == 'pull_request' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: Govulncheck
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary

Third in a sequence of release-pipeline fixes (after #77 and #78). The `chore(release):` merge commit updates each released module's `go.mod` to require a new `go.loglayer.dev` version (e.g. `v2.1.0`). The matching tag is created concurrently by `release.yml` on the same push. `ci.yml`'s `Verify modules tidy` step races with the tag push and loses, producing a phantom CI failure on every release:

```
go: go.loglayer.dev/transports/cli/v2 imports
    go.loglayer.dev/v2: reading go.loglayer.dev/go.mod at revision v2.1.0: unknown revision v2.1.0
```

Repro: https://github.com/loglayer/loglayer-go/actions/runs/25272543601/job/74097232242

Meanwhile `release.yml` on the same commit succeeds and the tags get pushed. The CI red-mark is misleading: the project is fine, it's just a workflow-ordering issue.

## Fix

Mirror the skip pattern `release-pr.yml` already uses: when the head commit subject starts with `chore(release):` on a push to `main`, skip the whole CI matrix. Pull-request runs are unaffected — the if-clause keeps PR triggers always-on.

Applied to all three top-level jobs (`test`, `staticcheck`, `govulncheck`) since each runs `go mod tidy` indirectly via `scripts/foreach-module.sh`.

## Upstream

Filed as a follow-up comment on https://github.com/disaresta-org/monorel/issues/54 — the recipe should be in monorel's CI docs so other adopters don't hit the same flake on every release.

## Test plan

- [ ] After merge, the next push-to-main with a non-`chore(release):` subject triggers a clean CI run.
- [ ] At the next release-pr merge, the chore(release) commit's `ci.yml` triggers but the test/staticcheck/govulncheck jobs all skip cleanly (no phantom red mark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)