### PR TITLE
fix: correct broken go.sum hashes from monorel chore(release): commit

### DIFF
--- a/examples/custom-plugin/go.mod
+++ b/examples/custom-plugin/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	go.loglayer.dev/transports/pretty/v2 v2.0.0-00010101000000-000000000000
-	go.loglayer.dev/v2 v2.0.1
+	go.loglayer.dev/v2 v2.1.0
 )
 
 require (

--- a/examples/datadog-shipping/go.mod
+++ b/examples/datadog-shipping/go.mod
@@ -13,7 +13,7 @@ require (
 	go.loglayer.dev/transports/datadog/v2 v2.0.0-00010101000000-000000000000
 	go.loglayer.dev/transports/http/v2 v2.0.1
 	go.loglayer.dev/transports/pretty/v2 v2.0.0-00010101000000-000000000000
-	go.loglayer.dev/v2 v2.0.1
+	go.loglayer.dev/v2 v2.1.0
 )
 
 require (

--- a/examples/multi-transport/go.mod
+++ b/examples/multi-transport/go.mod
@@ -11,7 +11,7 @@ replace (
 require (
 	go.loglayer.dev/transports/pretty/v2 v2.0.0-00010101000000-000000000000
 	go.loglayer.dev/transports/structured/v2 v2.0.0-00010101000000-000000000000
-	go.loglayer.dev/v2 v2.0.1
+	go.loglayer.dev/v2 v2.1.0
 )
 
 require (

--- a/examples/pretty-modes/go.mod
+++ b/examples/pretty-modes/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	go.loglayer.dev/transports/pretty/v2 v2.0.0-00010101000000-000000000000
-	go.loglayer.dev/v2 v2.0.1
+	go.loglayer.dev/v2 v2.1.0
 )
 
 require (

--- a/transports/cli/go.sum
+++ b/transports/cli/go.sum
@@ -6,7 +6,7 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-go.loglayer.dev/v2 v2.1.0 h1:jtVUg225o0K/7TCW5ob9OzjQLeRZxlNEIj8XbZOFjmY=
+go.loglayer.dev/v2 v2.1.0 h1:8/fq8Z1NNLtjfKgaPn6S0Hy7zWPnkjn9Gj3YgEDFk4w=
 go.loglayer.dev/v2 v2.1.0/go.mod h1:+BWhs5AyICvCLBz07qHnCE12W34tArUWfXOba0Ct/QI=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/transports/console/go.sum
+++ b/transports/console/go.sum
@@ -1,6 +1,6 @@
 github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
 github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
-go.loglayer.dev/v2 v2.1.0 h1:jtVUg225o0K/7TCW5ob9OzjQLeRZxlNEIj8XbZOFjmY=
+go.loglayer.dev/v2 v2.1.0 h1:8/fq8Z1NNLtjfKgaPn6S0Hy7zWPnkjn9Gj3YgEDFk4w=
 go.loglayer.dev/v2 v2.1.0/go.mod h1:+BWhs5AyICvCLBz07qHnCE12W34tArUWfXOba0Ct/QI=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/transports/pretty/go.sum
+++ b/transports/pretty/go.sum
@@ -6,7 +6,7 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-go.loglayer.dev/v2 v2.1.0 h1:jtVUg225o0K/7TCW5ob9OzjQLeRZxlNEIj8XbZOFjmY=
+go.loglayer.dev/v2 v2.1.0 h1:8/fq8Z1NNLtjfKgaPn6S0Hy7zWPnkjn9Gj3YgEDFk4w=
 go.loglayer.dev/v2 v2.1.0/go.mod h1:+BWhs5AyICvCLBz07qHnCE12W34tArUWfXOba0Ct/QI=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=


### PR DESCRIPTION
## Critical: v2.1.0 was published with the wrong h1: hash

PR #79 (the chore(release) merge from monorel) wrote an **incorrect** zip hash for `go.loglayer.dev/v2 v2.1.0` into the go.sum files of `transports/cli`, `transports/console`, and `transports/pretty`:

```
recorded: h1:jtVUg225o0K/7TCW5ob9OzjQLeRZxlNEIj8XbZOFjmY=
actual:   h1:8/fq8Z1NNLtjfKgaPn6S0Hy7zWPnkjn9Gj3YgEDFk4w=
```

The actual hash comes from `go mod download -x go.loglayer.dev/v2@v2.1.0` against the canonical bytes at the v2.1.0 tag. The recorded one is whatever pre-publish snapshot monorel hashed, which doesn't match what got tagged.

**Effect:** every fresh-cache install of `go.loglayer.dev/v2@v2.1.0` (or any of the dependent sub-module versions whose go.mod requires it) hits:

```
verifying go.loglayer.dev/v2@v2.1.0: checksum mismatch

SECURITY ERROR
This download does NOT match an earlier download recorded in go.sum.
```

Repro: https://github.com/loglayer/loglayer-go/actions/runs/25272682675/job/74097592843

## Fix

- Stripped the wrong `h1:` line from each of the three sub-module go.sum files and re-tidied with `GOPROXY=direct GOSUMDB=off go mod tidy` so the entry repopulates from the actual published bytes. The `/go.mod` sub-hash was correct in all three; only the full-zip hash was wrong.
- The pre-push hook then surfaced four example modules (`examples/{custom-plugin,datadog-shipping,multi-transport,pretty-modes}/go.mod`) still requiring `go.loglayer.dev/v2 v2.0.1` despite the chore(release). They're not in `monorel.toml`'s package list so monorel skipped them. Bumping to v2.1.0 to match the rest of the repo.

## Verification

- `bash scripts/foreach-module.sh tidy` is clean.
- `bash scripts/foreach-module.sh test` passes (33 modules).
- `GOPROXY=direct go mod download -x go.loglayer.dev/v2@v2.1.0` produces the new hash; the corrected go.sum entries match.

## Upstream

Filed as the latest comment on https://github.com/disaresta-org/monorel/issues/54. Two suggested fixes for monorel:
1. Compute the zip hash *after* writing the chore(release) state, then patch go.sum (two-pass).
2. Don't write cross-module hash entries in chore(release) at all; let consumers' fresh `go mod tidy` populate them post-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)