### PR TITLE
chore(ci): adopt monorel v0.14.0 and drop cache-priming workaround

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -33,25 +33,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      # The monorel CI action runs `go mod tidy` per sub-module with
-      # GOPROXY=off, so it can only resolve modules already in the local
-      # cache. Sub-modules also require Go 1.25, which the runner default
-      # doesn't supply. Install Go 1.25 with caching enabled, then prime
-      # the module cache via `go mod download` per module so monorel's
-      # GOPROXY=off tidy can find every transitive dep.
+      # monorel runs `go mod tidy` with GOTOOLCHAIN=local during release,
+      # so Go must already be installed at a version satisfying every
+      # released sub-module's `go` directive (every sub-module here is
+      # `go 1.25.0`).
       - uses: actions/setup-go@v5
         with:
           go-version: '1.25'
           cache: true
           cache-dependency-path: '**/go.sum'
 
-      - name: Prime module cache for monorel tidy
-        run: |
-          set -euo pipefail
-          while IFS= read -r mod; do
-            (cd "$(dirname "$mod")" && go mod download)
-          done < <(find . -name go.mod -not -path './.git/*' | sort)
-
-      - uses: disaresta-org/monorel/ci/github@v0.11.0
+      - uses: disaresta-org/monorel/ci/github@v0.14.0
         with:
           command: pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,26 +42,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      # The monorel CI action runs `go mod tidy` per sub-module with
-      # GOPROXY=off, so it can only resolve modules already in the local
-      # cache. Sub-modules also require Go 1.25, which the runner default
-      # doesn't supply. Install Go 1.25 with caching enabled, then prime
-      # the module cache via `go mod download` per module so monorel's
-      # GOPROXY=off tidy can find every transitive dep.
+      # monorel runs `go mod tidy` with GOTOOLCHAIN=local during release,
+      # so Go must already be installed at a version satisfying every
+      # released sub-module's `go` directive (every sub-module here is
+      # `go 1.25.0`).
       - uses: actions/setup-go@v5
         with:
           go-version: '1.25'
           cache: true
           cache-dependency-path: '**/go.sum'
 
-      - name: Prime module cache for monorel tidy
-        run: |
-          set -euo pipefail
-          while IFS= read -r mod; do
-            (cd "$(dirname "$mod")" && go mod download)
-          done < <(find . -name go.mod -not -path './.git/*' | sort)
-
-      - uses: disaresta-org/monorel/ci/github@v0.11.0
+      - uses: disaresta-org/monorel/ci/github@v0.14.0
         with:
           command: release
 


### PR DESCRIPTION
## Summary

Adopts [monorel v0.14.0](https://github.com/disaresta-org/monorel/releases/tag/v0.14.0), which ships the fixes for [issue #54](https://github.com/disaresta-org/monorel/issues/54) — the cacheseed wrong-h1: bug that broke our v2.1.0 release plus the cache-priming gap that initially blocked our `release-pr` workflow.

## Changes

- Bump `disaresta-org/monorel/ci/github` from `@v0.11.0` to `@v0.14.0` in both `release-pr.yml` and `release.yml`. Without this bump, the next `chore(release):` commit would ship broken `go.sum` entries (the same class of bug that caused the v2.1.0 SECURITY ERROR mismatch).
- Remove the "Prime module cache for monorel tidy" step from both workflows. monorel v0.14.0 does this internally per affected sub-module, filtering out managed siblings.

## Kept

- `actions/setup-go@v5` with `go-version: '1.25'` and `cache: true`. monorel still runs offline tidy with `GOTOOLCHAIN=local` (intentionally, for determinism), so the runner's Go must match every sub-module's `go` directive. v0.14.0's docs cover this requirement in [ci/github/README.md](https://github.com/disaresta-org/monorel/blob/main/ci/github/README.md) and [docs/src/workflows.md](https://github.com/disaresta-org/monorel/blob/main/docs/src/workflows.md).
- The `if: ... !startsWith(..., 'chore(release):')` skip filter on `ci.yml` jobs (PR #80). monorel doesn't auto-skip consumer CI workflows; the filter is the consumer's responsibility, and the pattern is now documented upstream.

## Test plan

- [ ] After merge, the next push-to-main triggers `release-pr` and the workflow completes successfully (release PR opens / updates).
- [ ] At the next release-pr merge, the `release` workflow runs the publish pipeline cleanly. The released sub-modules' `go.sum` entries record correct `h1:` hashes (verified by a downstream `go get` against the published versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)