### PR TITLE
docs: point Go Reference badges at /v2 import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://github.com/loglayer/loglayer-go/releases"><img src="https://img.shields.io/github/v/tag/loglayer/loglayer-go?filter=v*&sort=date&label=version&style=flat-square&color=blue" alt="Latest version"></a>
-  <a href="https://pkg.go.dev/go.loglayer.dev/v2"><img src="https://pkg.go.dev/badge/go.loglayer.dev.svg" alt="Go Reference"></a>
+  <a href="https://pkg.go.dev/go.loglayer.dev/v2"><img src="https://pkg.go.dev/badge/go.loglayer.dev/v2.svg" alt="Go Reference"></a>
   <a href="https://github.com/loglayer/loglayer-go/actions/workflows/ci.yml"><img src="https://github.com/loglayer/loglayer-go/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
 </p>

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -98,7 +98,7 @@ gtag('config', '${gaMeasurementId}');`,
     outline: { level: [2, 3] },
     nav: [
       { text: '<img alt="Latest version" src="https://img.shields.io/github/v/tag/loglayer/loglayer-go?filter=v*&amp;sort=date&amp;label=version&amp;style=flat-square&color=blue" />', link: 'https://github.com/loglayer/loglayer-go/releases' },
-      { text: '<img alt="Go Reference" src="https://pkg.go.dev/badge/go.loglayer.dev.svg" />', link: 'https://pkg.go.dev/go.loglayer.dev' },
+      { text: '<img alt="Go Reference" src="https://pkg.go.dev/badge/go.loglayer.dev/v2.svg" />', link: 'https://pkg.go.dev/go.loglayer.dev/v2' },
       { text: "What's New", link: '/whats-new' },
       { text: 'Get Started', link: '/getting-started' },
       { text: 'TypeScript Version', link: 'https://loglayer.dev' },

--- a/plugins/oteltrace/README.md
+++ b/plugins/oteltrace/README.md
@@ -1,6 +1,6 @@
 # go.loglayer.dev/plugins/oteltrace
 
-[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/plugins/oteltrace.svg)](https://pkg.go.dev/go.loglayer.dev/plugins/oteltrace)
+[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/plugins/oteltrace/v2.svg)](https://pkg.go.dev/go.loglayer.dev/plugins/oteltrace/v2)
 
 LogLayer plugin that injects the active OTel `trace_id` and `span_id` (plus optional trace flags, W3C trace state, and W3C baggage members) into every log entry that carries a `context.Context`. Use with non-OTel transports for log/trace correlation; `transports/otellog` does this automatically via the SDK.
 

--- a/transports/charmlog/README.md
+++ b/transports/charmlog/README.md
@@ -1,6 +1,6 @@
 # go.loglayer.dev/transports/charmlog
 
-[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/charmlog.svg)](https://pkg.go.dev/go.loglayer.dev/transports/charmlog)
+[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/charmlog/v2.svg)](https://pkg.go.dev/go.loglayer.dev/transports/charmlog/v2)
 
 LogLayer transport that wraps a `*charmbracelet/log.Logger`. Map metadata becomes individual key/value attrs; struct metadata lands under a configurable key. The package name is `charmlog` to avoid colliding with the stdlib `log`.
 

--- a/transports/datadog/README.md
+++ b/transports/datadog/README.md
@@ -1,6 +1,6 @@
 # go.loglayer.dev/transports/datadog
 
-[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/datadog.svg)](https://pkg.go.dev/go.loglayer.dev/transports/datadog)
+[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/datadog/v2.svg)](https://pkg.go.dev/go.loglayer.dev/transports/datadog/v2)
 
 Datadog Logs HTTP intake transport for LogLayer. Built on `transports/http` with a Datadog-specific encoder, site-aware URL, and `DD-API-KEY` header. Rejects non-https URLs by default; opt-in via `Config.AllowInsecureURL` for on-prem TLS-terminating proxies. The API key is redacted in `String()` output and tagged `json:"-"` to keep it out of accidental config dumps.
 

--- a/transports/http/README.md
+++ b/transports/http/README.md
@@ -1,6 +1,6 @@
 # go.loglayer.dev/transports/http
 
-[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/http.svg)](https://pkg.go.dev/go.loglayer.dev/transports/http)
+[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/http/v2.svg)](https://pkg.go.dev/go.loglayer.dev/transports/http/v2)
 
 Generic batched HTTP POST transport for LogLayer. Pluggable encoder, async worker, configurable batching and retries. Default `Client` refuses cross-host redirects so an `Authorization` header (or any other credential you set on the request) can't leak to a redirected host. Use it directly to talk to any log-ingestion API; the Datadog transport is built on top of it.
 

--- a/transports/logrus/README.md
+++ b/transports/logrus/README.md
@@ -1,6 +1,6 @@
 # go.loglayer.dev/transports/logrus
 
-[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/logrus.svg)](https://pkg.go.dev/go.loglayer.dev/transports/logrus)
+[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/logrus/v2.svg)](https://pkg.go.dev/go.loglayer.dev/transports/logrus/v2)
 
 LogLayer transport that wraps a `*logrus.Logger`. Map metadata becomes individual logrus fields; struct metadata lands under a configurable key. Fatal-level entries route through `Log()` so loglayer's `DisableFatalExit` is honored.
 

--- a/transports/lumberjack/README.md
+++ b/transports/lumberjack/README.md
@@ -1,6 +1,6 @@
 # go.loglayer.dev/transports/lumberjack
 
-[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/lumberjack.svg)](https://pkg.go.dev/go.loglayer.dev/transports/lumberjack)
+[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/lumberjack/v2.svg)](https://pkg.go.dev/go.loglayer.dev/transports/lumberjack/v2)
 
 File transport for LogLayer with built-in rotation. Writes one JSON object per log entry; rotation is delegated to [lumberjack.v2](https://github.com/natefinch/lumberjack) (size-triggered rollover, backup retention, age-based cleanup, optional gzip compression). On-disk format matches `transports/structured`.
 

--- a/transports/otellog/README.md
+++ b/transports/otellog/README.md
@@ -1,6 +1,6 @@
 # go.loglayer.dev/transports/otellog
 
-[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/otellog.svg)](https://pkg.go.dev/go.loglayer.dev/transports/otellog)
+[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/otellog/v2.svg)](https://pkg.go.dev/go.loglayer.dev/transports/otellog/v2)
 
 OpenTelemetry Logs transport for LogLayer. Emits each entry as an OTel `log.Record` on a configured `LoggerProvider`, propagating `WithContext` so the SDK's span correlation works.
 

--- a/transports/phuslu/README.md
+++ b/transports/phuslu/README.md
@@ -1,6 +1,6 @@
 # go.loglayer.dev/transports/phuslu
 
-[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/phuslu.svg)](https://pkg.go.dev/go.loglayer.dev/transports/phuslu)
+[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/phuslu/v2.svg)](https://pkg.go.dev/go.loglayer.dev/transports/phuslu/v2)
 
 LogLayer transport that wraps a `*phuslu/log.Logger`. Map metadata becomes individual phuslu fields; struct metadata lands under a configurable key. **Fatal entries always exit the process** since phuslu has no public hook to suppress its `os.Exit` (every other wrapper honors `Config.DisableFatalExit`).
 

--- a/transports/pretty/README.md
+++ b/transports/pretty/README.md
@@ -1,6 +1,6 @@
 # go.loglayer.dev/transports/pretty
 
-[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/pretty.svg)](https://pkg.go.dev/go.loglayer.dev/transports/pretty)
+[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/pretty/v2.svg)](https://pkg.go.dev/go.loglayer.dev/transports/pretty/v2)
 
 Colorized terminal renderer for LogLayer. Theme-aware, three view modes (inline, message-only, expanded). Color auto-disables when stdout isn't a TTY. Recommended for local development.
 

--- a/transports/sentry/README.md
+++ b/transports/sentry/README.md
@@ -1,6 +1,6 @@
 # go.loglayer.dev/transports/sentry
 
-[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/sentry.svg)](https://pkg.go.dev/go.loglayer.dev/transports/sentry)
+[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/sentry/v2.svg)](https://pkg.go.dev/go.loglayer.dev/transports/sentry/v2)
 
 LogLayer transport that forwards entries to a caller-supplied `sentry.Logger` (Sentry's structured-logs API). The user owns Sentry initialization; this transport just hands each entry off via the chain-builder API. Fatal-level entries skip Sentry's `Fatal()` / `Panic()` (which would terminate the process) so loglayer's `DisableFatalExit` is honored.
 

--- a/transports/zap/README.md
+++ b/transports/zap/README.md
@@ -1,6 +1,6 @@
 # go.loglayer.dev/transports/zap
 
-[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/zap.svg)](https://pkg.go.dev/go.loglayer.dev/transports/zap)
+[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/zap/v2.svg)](https://pkg.go.dev/go.loglayer.dev/transports/zap/v2)
 
 LogLayer transport that wraps a `*zap.Logger`. Map metadata becomes individual zap fields; struct metadata lands under a configurable key. Fatal-level entries are routed through a custom `CheckWriteHook` so loglayer's `DisableFatalExit` is honored.
 

--- a/transports/zerolog/README.md
+++ b/transports/zerolog/README.md
@@ -1,6 +1,6 @@
 # go.loglayer.dev/transports/zerolog
 
-[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/zerolog.svg)](https://pkg.go.dev/go.loglayer.dev/transports/zerolog)
+[![Go Reference](https://pkg.go.dev/badge/go.loglayer.dev/transports/zerolog/v2.svg)](https://pkg.go.dev/go.loglayer.dev/transports/zerolog/v2)
 
 LogLayer transport that wraps a `*zerolog.Logger`. Map metadata becomes individual zerolog fields; struct metadata lands under a configurable key. Fatal-level entries skip zerolog's default `os.Exit` so loglayer's `DisableFatalExit` is honored.
 


### PR DESCRIPTION
The README and the docs site's nav both linked the Go Reference badge to `pkg.go.dev/go.loglayer.dev` (no `/v2`). pkg.go.dev shows the latest tag at that import path, which is `v1.7.0` (the last v1 release before the v2 cascade). The badge therefore showed `v1.7.0` even though the live module path is `go.loglayer.dev/v2` and the latest release is `v2.1.0`.

## Two commits

1. **Root README + VitePress nav** badge image URL and click-through link both get `/v2`.
2. **Sub-module READMEs** (11 transports + `plugins/oteltrace`) get the same fix. The eight other sub-modules don't ship per-package READMEs; their badges in the docs site's `transport-list.md` and `plugin-list.md` partials already use `/v2` correctly.

## Verification

- `cd docs && bun run docs:build` clean (verified before each push).
- After merge, every Go Reference badge across the project resolves to the v2 module's pkg.go.dev page and shows the v2.x version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)